### PR TITLE
Precompute rotated footprints for angle bins

### DIFF
--- a/include/smac_planner/collision_checker.hpp
+++ b/include/smac_planner/collision_checker.hpp
@@ -127,7 +127,10 @@ protected:
   std::unique_ptr<base_local_planner::CostmapModel> world_model_;
   std::shared_ptr<costmap_2d::Costmap2DROS> costmap_ros_;
   std::shared_ptr<costmap_2d::Costmap2D> costmap_;
+  std::vector<Footprint> oriented_footprints_;
   Footprint unoriented_footprint_;
+  double inscribed_radius_;
+  double circumscribed_radius_;
   float footprint_cost_;
   bool footprint_is_radius_;
   std::vector<float> angles_;


### PR DESCRIPTION
[AB#12487](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/12487)

I dropped this during backporting, but there's no good reason for that, so restored.

The gain in time is around 14% for calls to `footprintCost`, but I didn't notice any overall performance improvement