### PR TITLE
Obtain orientation bin by rounding (not flooring) angles

### DIFF
--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -328,7 +328,8 @@ MotionPoses HybridMotionTable::getProjections(const NodeHybrid * node)
 
 unsigned int HybridMotionTable::getClosestAngularBin(const double & theta)
 {
-  return static_cast<unsigned int>(floor(static_cast<float>(theta) / bin_size));
+  auto bin = static_cast<unsigned int>(round(static_cast<float>(theta) / bin_size));
+  return bin < num_angle_quantization ? bin : 0;
 }
 
 float HybridMotionTable::getAngleFromBin(const unsigned int & bin_idx)

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -199,7 +199,7 @@ uint32_t SmacPlannerHybrid::makePlan(
     return mbf_msgs::GetPathResult::OUT_OF_MAP;
   }
 
-  double orientation_bin = tf2::getYaw(start.pose.orientation) / _angle_bin_size;
+  double orientation_bin = std::round(tf2::getYaw(start.pose.orientation) / _angle_bin_size);
   while (orientation_bin < 0.0) {
     orientation_bin += static_cast<float>(_angle_quantizations);
   }
@@ -207,7 +207,7 @@ uint32_t SmacPlannerHybrid::makePlan(
   if (orientation_bin >= static_cast<float>(_angle_quantizations)) {
     orientation_bin -= static_cast<float>(_angle_quantizations);
   }
-  unsigned int orientation_bin_id = static_cast<unsigned int>(floor(orientation_bin));
+  unsigned int orientation_bin_id = static_cast<unsigned int>(orientation_bin);
 
   if (_collision_checker.inCollision(mx, my, orientation_bin_id, _config.allow_unknown)) {
     message = "Start pose is blocked";
@@ -223,7 +223,7 @@ uint32_t SmacPlannerHybrid::makePlan(
     return mbf_msgs::GetPathResult::OUT_OF_MAP;
   }
 
-  orientation_bin = tf2::getYaw(goal.pose.orientation) / _angle_bin_size;
+  orientation_bin = round(tf2::getYaw(goal.pose.orientation) / _angle_bin_size);
   while (orientation_bin < 0.0) {
     orientation_bin += static_cast<float>(_angle_quantizations);
   }
@@ -231,7 +231,7 @@ uint32_t SmacPlannerHybrid::makePlan(
   if (orientation_bin >= static_cast<float>(_angle_quantizations)) {
     orientation_bin -= static_cast<float>(_angle_quantizations);
   }
-  orientation_bin_id = static_cast<unsigned int>(floor(orientation_bin));
+  orientation_bin_id = static_cast<unsigned int>(orientation_bin);
 
   if (_collision_checker.inCollision(mx, my, orientation_bin_id, _config.allow_unknown)) {
     message = "Goal pose is blocked";


### PR DESCRIPTION
https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/12486

Hybrid A* operates with quantizied angles (72 bins by default) so it convert all angles (including start and goal poses) to a bin.
It does that by dividing the angles by angle_bin_size (2pi / 72) and getting the interger part using `floor`. This introduces quantization errors of up to 0.087266463 radians, which causes 2 issues:

- On GG strategy, path_planner can fail [here](https://github.com/rapyuta-robotics/rr_navigation/blob/9a8e2547e9a7988aa7297f06704da62aaec9c1d4/rr_nav_mbf_helpers/src/path_planner.cpp#L384-L390) if we use angle tolerance < 0.087266463
- Can happen that the quantizied start pose is in collision but the actual pose (with continuous angle) is not. Planning fail but the out_of_collision recovery does nothing cause we are not in collision. This can also happen with the goal, but in this case there are no negative effects.

This PR changes quantization to use round instead of floor.
1. makes sense
2. haves the problem; now worst error is 0,043633231, above the minimum tolerance we use (0.05)