### PR TITLE
Fix costmap downsampling

### DIFF
--- a/include/smac_planner/collision_checker.hpp
+++ b/include/smac_planner/collision_checker.hpp
@@ -50,7 +50,7 @@ public:
    */
   costmap_2d::Costmap2D* getCostmap()
   {
-    return costmap_.get();
+    return costmap_;
   }
 
   /**
@@ -126,8 +126,8 @@ private:
 protected:
   std::unique_ptr<base_local_planner::CostmapModel> world_model_;
   std::shared_ptr<costmap_2d::Costmap2DROS> costmap_ros_;
-  std::shared_ptr<costmap_2d::Costmap2D> costmap_;
-  std::vector<Footprint> oriented_footprints_;
+  costmap_2d::Costmap2D* costmap_;  // this can point to the downsampled costmap instead of the one inside costmap_ros_
+  std::vector<Footprint> oriented_footprints_;  // footprints oriented for each of the angle bins
   Footprint unoriented_footprint_;
   double inscribed_radius_;
   double circumscribed_radius_;

--- a/include/smac_planner/node_hybrid.hpp
+++ b/include/smac_planner/node_hybrid.hpp
@@ -427,7 +427,7 @@ public:
    * @param goal_coords Coordinates to start heuristic expansion at
    */
   static void resetObstacleHeuristic(
-    std::shared_ptr<costmap_2d::Costmap2DROS> costmap_ros,
+    const std::shared_ptr<costmap_2d::Costmap2DROS>& costmap_ros,
     const unsigned int & start_x, const unsigned int & start_y,
     const unsigned int & goal_x, const unsigned int & goal_y);
 

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -95,7 +95,7 @@ protected:
   std::unique_ptr<dynamic_reconfigure::Server<SmacPlannerHybridConfig>> dsrv_;
 
   std::unique_ptr<AStarAlgorithm<NodeHybrid>> _a_star;
-  GridCollisionChecker _collision_checker;
+  std::unique_ptr<GridCollisionChecker> _collision_checker;
   Smoother _path_smoother;
   costmap_2d::Costmap2D * _costmap;
   std::shared_ptr<costmap_2d::Costmap2DROS> _costmap_ros;

--- a/src/collision_checker.cpp
+++ b/src/collision_checker.cpp
@@ -33,8 +33,6 @@ GridCollisionChecker::GridCollisionChecker(
 
   if (costmap_ros) {
     costmap_ros_ = costmap_ros;
-    costmap_ = std::shared_ptr<costmap_2d::Costmap2D>(costmap_ros_->getCostmap());
-    world_model_ = std::make_unique<base_local_planner::CostmapModel>(*costmap_);
     setFootprint(
         costmap_ros_->getRobotFootprint(),
         costmap_ros_->getUseRadius(),
@@ -44,7 +42,7 @@ GridCollisionChecker::GridCollisionChecker(
 
 void GridCollisionChecker::setCostmap(costmap_2d::Costmap2D* costmap)
 {
-  costmap_ = std::shared_ptr<costmap_2d::Costmap2D>(costmap);
+  costmap_ = costmap;
   world_model_ = std::make_unique<base_local_planner::CostmapModel>(*costmap_);
 }
 

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -476,7 +476,7 @@ inline float distanceHeuristic2D(
 }
 
 void NodeHybrid::resetObstacleHeuristic(
-  std::shared_ptr<costmap_2d::Costmap2DROS> costmap_ros_i,
+  const std::shared_ptr<costmap_2d::Costmap2DROS> & costmap_ros_i,
   const unsigned int & start_x, const unsigned int & start_y,
   const unsigned int & goal_x, const unsigned int & goal_y)
 {


### PR DESCRIPTION
[AB#14463](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/14463)

Problem is that [here](https://github.com/rapyuta-robotics/smac_planner/pull/3/files#diff-b075398420e4847677d89013cc6c6cf6a97d43bcfb1ddcdf1bdd38ce8ad17d8bL36-R45) we were destroying the global Costmap2d object contained inside the Costmap2dROS.

![image](https://github.com/user-attachments/assets/876b4f83-c63d-4609-86a6-7ca8cc1dcc0d)

With subsampling factor = 5  (resolution 2 -> 10 cm)

![image](https://github.com/user-attachments/assets/1ca00f74-4f37-46ee-bd33-35ea99252d4b)

