### PR TITLE
Fix path smoothing and downsampled costmap visualization

### DIFF
--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -87,7 +87,7 @@ public:
 protected:
   // Dynamic parameters handler
   /**
-   * @brief Callback executed when a paramter change is detected
+   * @brief Callback executed when a parameter change is detected
    * @param config Planner configuration
    */
   void reconfigureCB(SmacPlannerHybridConfig& config, uint32_t level);

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -205,33 +205,23 @@ public:
    * @return marker populated
    */
   static inline visualization_msgs::Marker createMarker(
-      const std::vector<geometry_msgs::Point> edge,
+      const std::vector<geometry_msgs::Point>& edge,
       unsigned int i, const std::string &frame_id, const ros::Time &timestamp) {
     visualization_msgs::Marker marker;
     marker.header.frame_id = frame_id;
     marker.header.stamp = timestamp;
     marker.frame_locked = false;
+    marker.id = i;
     marker.ns = "planned_footprint";
     marker.action = visualization_msgs::Marker::ADD;
     marker.type = visualization_msgs::Marker::LINE_LIST;
     marker.lifetime = ros::Duration(0, 0);
-
-    marker.id = i;
-    for (auto &point: edge) {
-      marker.points.push_back(point);
-    }
-
-    marker.pose.orientation.x = 0.0;
-    marker.pose.orientation.y = 0.0;
-    marker.pose.orientation.z = 0.0;
+    marker.points = edge;
     marker.pose.orientation.w = 1.0;
-    marker.scale.x = 0.05;
-    marker.scale.y = 0.05;
-    marker.scale.z = 0.05;
-    marker.color.r = 0.0f;
-    marker.color.g = 0.0f;
-    marker.color.b = 1.0f;
-    marker.color.a = 1.3f;
+    marker.scale.x = 0.01;
+    marker.color.r = 0.8f;
+    marker.color.g = 0.6f;
+    marker.color.a = 0.8f;
     return marker;
   }
 };

--- a/src/costmap_downsampler.cpp
+++ b/src/costmap_downsampler.cpp
@@ -51,7 +51,7 @@ void CostmapDownsampler::on_configure(
     _costmap->getOriginX(), _costmap->getOriginY(), UNKNOWN);
 
   _downsampled_costmap_pub = std::make_unique<costmap_2d::Costmap2DPublisher>(
-    &_pnh, _downsampled_costmap.get(), global_frame, topic_name, false);
+    &_pnh, _downsampled_costmap.get(), global_frame, topic_name, true);
 }
 
 void CostmapDownsampler::on_cleanup()

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -351,13 +351,15 @@ uint32_t SmacPlannerHybrid::makePlan(
 #endif
 
   // Smooth output_path
-  if (_config.smooth_path && num_iterations > 1) {
-    _path_smoother.smooth(output_path, costmap, time_remaining);
-
+  if (_config.smooth_path) {
     // Publish raw path for comparison
     if (_raw_plan_publisher.getNumSubscribers() > 0) {
       _raw_plan_publisher.publish(output_path);
     }
+    // overwrite start and goal poses to eliminate quantization-induced deviations
+    output_path.poses.front() = start;
+    output_path.poses.back() = goal;
+    _path_smoother.smooth(output_path, costmap, time_remaining);
   }
 
   if (_final_plan_publisher.getNumSubscribers() > 0) {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -325,17 +325,14 @@ uint32_t SmacPlannerHybrid::makePlan(
 
     // plot footprint path planned for debug
     if (_planned_footprints_publisher.getNumSubscribers() > 0) {
+      visualization_msgs::Marker clear_all_marker;
+      clear_all_marker.action = visualization_msgs::Marker::DELETEALL;
       visualization_msgs::MarkerArray marker_array;
+      marker_array.markers.push_back(clear_all_marker);
       for (size_t i = 0; i < output_path.poses.size(); i++) {
         const std::vector<geometry_msgs::Point> edge =
             Utils::transformFootprintToEdges(output_path.poses[i].pose, _costmap_ros->getRobotFootprint());
         marker_array.markers.push_back(Utils::createMarker(edge, i, _global_frame, ros::Time::now()));
-      }
-
-      if (marker_array.markers.empty()) {
-        visualization_msgs::Marker clear_all_marker;
-        clear_all_marker.action = visualization_msgs::Marker::DELETEALL;
-        marker_array.markers.push_back(clear_all_marker);
       }
       _planned_footprints_publisher.publish(marker_array);
     }


### PR DESCRIPTION
Also overwrite start and goal poses to eliminate quantization-induced deviations

I wrote a note about this problem on nav_bringup configuration, reproduced here:

```
# Important Note on costmap downsampling and angle quantization:
#   the start and goal poses of the resulting paths are adjusted to fit the downsampled costmap cell size and
#   the quantized angles. This means the final start and goal poses might be different from the original ones,
#   especially if the downsampling factor is large or the number of angle quantization bins is small.
#   However, this does not apply to smoothed paths, as we use the original start and goal poses.
```