### PR TITLE
feat: add param allow_goal_overshoot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(smac_planner)
-
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(catkin REQUIRED COMPONENTS
         roscpp
         dynamic_reconfigure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(${library_name} SHARED
         src/costmap_downsampler.cpp
         src/node_2d.cpp
         src/node_basic.cpp
+        src/types.cpp
 )
 
 target_link_libraries(${library_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(smac_planner)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(catkin REQUIRED COMPONENTS

--- a/cfg/SmacPlannerHybrid.cfg
+++ b/cfg/SmacPlannerHybrid.cfg
@@ -27,7 +27,7 @@ motion_model_enum = gen.enum([
 ], "Motion model")
 
 grp_searching = gen.add_group("Searching", type="tab")
-grp_searching.add("disable_goal_overshoot", bool_t, 0, "We will ignore the cells which are in front of the pose when searching, so the path never goes ahead of the goal, the planning will fail if start pose and goal pose are facing the opposite direction.", False)
+grp_searching.add("disable_goal_overshoot", bool_t, 0, "Dont search in cells which are on opposite side of the goal pose, compared to the side where the start pose is", False)
 grp_searching.add("motion_model_for_search", int_t, 0, "", 2, 2, 3, edit_method=motion_model_enum)
 grp_searching.add("analytic_expansion_ratio", double_t, 0, "The ratio to attempt analytic expansions during search for final approach", 3.5, 0.0, 10.0)
 grp_searching.add("analytic_expansion_max_length", double_t, 0, "The maximum length of the analytic expansion to be considered valid to prevent unsafe shortcutting (in meters). This should be scaled with minimum turning radius and be no less than 4-5x the minimum radius", 3.0, 0, 200.0)

--- a/cfg/SmacPlannerHybrid.cfg
+++ b/cfg/SmacPlannerHybrid.cfg
@@ -27,7 +27,7 @@ motion_model_enum = gen.enum([
 ], "Motion model")
 
 grp_searching = gen.add_group("Searching", type="tab")
-grp_searching.add("disable_goal_overshoot", bool_t, 0, False)
+grp_searching.add("disable_goal_overshoot", bool_t, 0, "We will ignore the cells which are in front of the pose when searching, so the path never goes ahead of the goal, the planning will fail if start pose and goal pose are facing the opposite direction.", False)
 grp_searching.add("motion_model_for_search", int_t, 0, "", 2, 2, 3, edit_method=motion_model_enum)
 grp_searching.add("analytic_expansion_ratio", double_t, 0, "The ratio to attempt analytic expansions during search for final approach", 3.5, 0.0, 10.0)
 grp_searching.add("analytic_expansion_max_length", double_t, 0, "The maximum length of the analytic expansion to be considered valid to prevent unsafe shortcutting (in meters). This should be scaled with minimum turning radius and be no less than 4-5x the minimum radius", 3.0, 0, 200.0)

--- a/cfg/SmacPlannerHybrid.cfg
+++ b/cfg/SmacPlannerHybrid.cfg
@@ -27,7 +27,7 @@ motion_model_enum = gen.enum([
 ], "Motion model")
 
 grp_searching = gen.add_group("Searching", type="tab")
-grp_searching.add("allow_goal_overshoot", bool_t, 0, "Dont search in cells which are on opposite side of the goal pose, compared to the side where the start pose is", True)
+grp_searching.add("allow_goal_overshoot", bool_t, 0, "If false, don't search in cells which are on opposite side of the goal pose, compared to the side where the start pose is", True)
 grp_searching.add("motion_model_for_search", int_t, 0, "", 2, 2, 3, edit_method=motion_model_enum)
 grp_searching.add("analytic_expansion_ratio", double_t, 0, "The ratio to attempt analytic expansions during search for final approach", 3.5, 0.0, 10.0)
 grp_searching.add("analytic_expansion_max_length", double_t, 0, "The maximum length of the analytic expansion to be considered valid to prevent unsafe shortcutting (in meters). This should be scaled with minimum turning radius and be no less than 4-5x the minimum radius", 3.0, 0, 200.0)

--- a/cfg/SmacPlannerHybrid.cfg
+++ b/cfg/SmacPlannerHybrid.cfg
@@ -27,6 +27,7 @@ motion_model_enum = gen.enum([
 ], "Motion model")
 
 grp_searching = gen.add_group("Searching", type="tab")
+grp_searching.add("disable_goal_overshoot", bool_t, 0, False)
 grp_searching.add("motion_model_for_search", int_t, 0, "", 2, 2, 3, edit_method=motion_model_enum)
 grp_searching.add("analytic_expansion_ratio", double_t, 0, "The ratio to attempt analytic expansions during search for final approach", 3.5, 0.0, 10.0)
 grp_searching.add("analytic_expansion_max_length", double_t, 0, "The maximum length of the analytic expansion to be considered valid to prevent unsafe shortcutting (in meters). This should be scaled with minimum turning radius and be no less than 4-5x the minimum radius", 3.0, 0, 200.0)

--- a/cfg/SmacPlannerHybrid.cfg
+++ b/cfg/SmacPlannerHybrid.cfg
@@ -27,7 +27,7 @@ motion_model_enum = gen.enum([
 ], "Motion model")
 
 grp_searching = gen.add_group("Searching", type="tab")
-grp_searching.add("disable_goal_overshoot", bool_t, 0, "Dont search in cells which are on opposite side of the goal pose, compared to the side where the start pose is", False)
+grp_searching.add("allow_goal_overshoot", bool_t, 0, "Dont search in cells which are on opposite side of the goal pose, compared to the side where the start pose is", True)
 grp_searching.add("motion_model_for_search", int_t, 0, "", 2, 2, 3, edit_method=motion_model_enum)
 grp_searching.add("analytic_expansion_ratio", double_t, 0, "The ratio to attempt analytic expansions during search for final approach", 3.5, 0.0, 10.0)
 grp_searching.add("analytic_expansion_max_length", double_t, 0, "The maximum length of the analytic expansion to be considered valid to prevent unsafe shortcutting (in meters). This should be scaled with minimum turning radius and be no less than 4-5x the minimum radius", 3.0, 0, 200.0)

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -25,6 +25,8 @@
 #include <tuple>
 #include "Eigen/Core"
 #include "costmap_2d/costmap_2d.h"
+#include "geometry_msgs/Pose.h"
+#include "geometry_msgs/PoseStamped.h"
 #include "smac_planner/thirdparty/robin_hood.h"
 #include "smac_planner/analytic_expansion.hpp"
 #include "smac_planner/node_2d.hpp"
@@ -53,6 +55,7 @@ public:
   typedef typename NodeT::CoordinateVector CoordinateVector;
   typedef typename NodeVector::iterator NeighborIterator;
   typedef std::function<bool (const unsigned int &, NodeT * &)> NodeGetter;
+  bool _is_start_behind_goal;
 
   /**
    * @struct smac_planner::NodeComparator
@@ -118,9 +121,7 @@ public:
    * @param collision_checker Collision checker to use for checking state validity
    */
   void setCollisionChecker(GridCollisionChecker * collision_checker);
-
-  void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, const geometry_msgs::PoseStamped& start);
-  void clearSearchBounds();
+  void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal);
 
   /**
    * @brief Set the goal for planning, as a node index

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -22,7 +22,6 @@
 #include <memory>
 #include <queue>
 #include <utility>
-#include <optional>
 #include <tuple>
 #include "Eigen/Core"
 #include "costmap_2d/costmap_2d.h"

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -251,9 +251,6 @@ protected:
   inline void populateExpansionsLog(
     const NodePtr & node, std::vector<std::tuple<float, float, float>> * expansions_log);
 
-  inline float getDistanceToGoal(
-      const NodePtr & node, std::vector<float> goal_pose);
-
   inline bool checkNodeBelowPose(
         const NodePtr & node, const geometry_msgs::PoseStamped & pose);
 

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -251,7 +251,7 @@ protected:
    * @param node the node which we want to check
    * @param pose the pose relative to which we want to check the position of the node
    */
-  bool isNodeBelowPose(const NodePtr& node, const geometry_msgs::PoseStamped& pose);
+  bool isBehindPose(const NodePtr& node, const geometry_msgs::Pose& pose);
 
     /**
    * @brief Clear Start

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -121,6 +121,8 @@ public:
   void setCollisionChecker(GridCollisionChecker * collision_checker);
 
   void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds);
+  void clearSearchBounds();
+
   /**
    * @brief Set the goal for planning, as a node index
    * @param mx The node X index of the goal
@@ -278,7 +280,6 @@ protected:
 
   Graph _graph;
   NodeQueue _queue;
-  std::optional<geometry_msgs::PoseStamped> _search_bounds;
   MotionModel _motion_model;
   NodeHeuristicPair _best_heuristic_node;
 

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -17,21 +17,17 @@
 #define SMAC_PLANNER__A_STAR_HPP_
 
 #include <vector>
-#include <iostream>
-#include <unordered_map>
 #include <memory>
 #include <queue>
 #include <utility>
 #include <tuple>
-#include "Eigen/Core"
+
 #include "costmap_2d/costmap_2d.h"
-#include "geometry_msgs/Pose.h"
+
 #include "geometry_msgs/PoseStamped.h"
 #include "smac_planner/thirdparty/robin_hood.h"
 #include "smac_planner/analytic_expansion.hpp"
 #include "smac_planner/node_2d.hpp"
-#include "smac_planner/node_hybrid.hpp"
-#include "smac_planner/node_lattice.hpp"
 #include "smac_planner/node_basic.hpp"
 #include "smac_planner/types.hpp"
 #include "smac_planner/constants.hpp"
@@ -281,6 +277,7 @@ protected:
 
   Graph _graph;
   NodeQueue _queue;
+
   MotionModel _motion_model;
   NodeHeuristicPair _best_heuristic_node;
 

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -116,7 +116,14 @@ public:
    * @param collision_checker Collision checker to use for checking state validity
    */
   void setCollisionChecker(GridCollisionChecker * collision_checker);
-  void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal);
+
+    /**
+   * @brief Used to limit the planner to explore ahead of the specified pose
+   * @param search_bounds the pose beyoind which we want to limit the planner
+   * @param start_point the start point
+   * @param allow_goal_overshoot enable/disable this feature
+   */
+  void setSearchBounds(const geometry_msgs::Pose& search_bounds, const geometry_msgs::Point& start_point, bool allow_goal_overshoot);
 
   /**
    * @brief Set the goal for planning, as a node index

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -51,7 +51,6 @@ public:
   typedef typename NodeT::CoordinateVector CoordinateVector;
   typedef typename NodeVector::iterator NeighborIterator;
   typedef std::function<bool (const unsigned int &, NodeT * &)> NodeGetter;
-  bool _is_start_behind_goal;
 
   /**
    * @struct smac_planner::NodeComparator

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -22,11 +22,10 @@
 #include <memory>
 #include <queue>
 #include <utility>
+#include <optional>
 #include <tuple>
 #include "Eigen/Core"
-
 #include "costmap_2d/costmap_2d.h"
-
 #include "smac_planner/thirdparty/robin_hood.h"
 #include "smac_planner/analytic_expansion.hpp"
 #include "smac_planner/node_2d.hpp"
@@ -121,6 +120,7 @@ public:
    */
   void setCollisionChecker(GridCollisionChecker * collision_checker);
 
+  void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds);
   /**
    * @brief Set the goal for planning, as a node index
    * @param mx The node X index of the goal
@@ -249,7 +249,13 @@ protected:
   inline void populateExpansionsLog(
     const NodePtr & node, std::vector<std::tuple<float, float, float>> * expansions_log);
 
-  /**
+  inline float getDistanceToGoal(
+      const NodePtr & node, std::vector<float> goal_pose);
+
+  inline bool checkNodeBelowPose(
+        const NodePtr & node, const geometry_msgs::PoseStamped & pose);
+
+    /**
    * @brief Clear Start
    */
   void clearStart();
@@ -272,7 +278,7 @@ protected:
 
   Graph _graph;
   NodeQueue _queue;
-
+  std::optional<geometry_msgs::PoseStamped> _search_bounds;
   MotionModel _motion_model;
   NodeHeuristicPair _best_heuristic_node;
 

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -120,7 +120,7 @@ public:
    */
   void setCollisionChecker(GridCollisionChecker * collision_checker);
 
-  void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds);
+  void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, bool behind);
   void clearSearchBounds();
 
   /**

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -252,7 +252,7 @@ protected:
    * @param node the node which we want to check
    * @param pose the pose relative to which we want to check the position of the node
    */
-  bool checkNodeBelowPose(const NodePtr& node, const geometry_msgs::PoseStamped& pose);
+  bool isNodeBelowPose(const NodePtr& node, const geometry_msgs::PoseStamped& pose);
 
     /**
    * @brief Clear Start

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -120,7 +120,7 @@ public:
    */
   void setCollisionChecker(GridCollisionChecker * collision_checker);
 
-  void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, bool behind);
+  void setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, const geometry_msgs::PoseStamped& start);
   void clearSearchBounds();
 
   /**
@@ -251,8 +251,12 @@ protected:
   inline void populateExpansionsLog(
     const NodePtr & node, std::vector<std::tuple<float, float, float>> * expansions_log);
 
-  inline bool checkNodeBelowPose(
-        const NodePtr & node, const geometry_msgs::PoseStamped & pose);
+  /**
+   * @brief check the position of a node, with respect to a pose. If it is behind the pose then return true
+   * @param node the node which we want to check
+   * @param pose the pose relative to which we want to check the position of the node
+   */
+  inline bool checkNodeBelowPose(const NodePtr& node, const geometry_msgs::PoseStamped& pose);
 
     /**
    * @brief Clear Start

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -252,7 +252,7 @@ protected:
    * @param node the node which we want to check
    * @param pose the pose relative to which we want to check the position of the node
    */
-  inline bool checkNodeBelowPose(const NodePtr& node, const geometry_msgs::PoseStamped& pose);
+  bool checkNodeBelowPose(const NodePtr& node, const geometry_msgs::PoseStamped& pose);
 
     /**
    * @brief Clear Start

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -36,7 +36,6 @@ public:
   typedef NodeT * NodePtr;
   typedef typename NodeT::Coordinates Coordinates;
   typedef std::function<bool (const unsigned int &, NodeT * &)> NodeGetter;
-  bool _is_start_behind_goal;
 
   /**
    * @struct smac_planner::AnalyticExpansion::AnalyticExpansionNodes

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -119,6 +119,8 @@ public:
    * @param expanded_nodes Expanded node to clean up from search
    */
   void cleanNode(const NodePtr & nodes);
+  void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds);
+  void clearSearchBounds();
 
 protected:
   MotionModel _motion_model;

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -36,6 +36,7 @@ public:
   typedef NodeT * NodePtr;
   typedef typename NodeT::Coordinates Coordinates;
   typedef std::function<bool (const unsigned int &, NodeT * &)> NodeGetter;
+  bool _is_start_behind_goal = _is_start_behind_goal;
 
   /**
    * @struct smac_planner::AnalyticExpansion::AnalyticExpansionNodes
@@ -119,7 +120,7 @@ public:
    * @param expanded_nodes Expanded node to clean up from search
    */
   void cleanNode(const NodePtr & nodes);
-  void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds, const geometry_msgs::PoseStamped& start);
+  void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal);
   void clearSearchBounds();
 
 protected:

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -119,7 +119,7 @@ public:
    * @param expanded_nodes Expanded node to clean up from search
    */
   void cleanNode(const NodePtr & nodes);
-  void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds, bool behind);
+  void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds, const geometry_msgs::PoseStamped& start);
   void clearSearchBounds();
 
 protected:

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -36,7 +36,7 @@ public:
   typedef NodeT * NodePtr;
   typedef typename NodeT::Coordinates Coordinates;
   typedef std::function<bool (const unsigned int &, NodeT * &)> NodeGetter;
-  bool _is_start_behind_goal = _is_start_behind_goal;
+  bool _is_start_behind_goal;
 
   /**
    * @struct smac_planner::AnalyticExpansion::AnalyticExpansionNodes

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -20,7 +20,7 @@
 #include <list>
 #include <memory>
 
-#include "geometry_msgs/Point.h"
+#include <geometry_msgs/Point.h>
 #include "smac_planner/node_2d.hpp"
 #include "smac_planner/node_hybrid.hpp"
 #include "smac_planner/node_lattice.hpp"

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -120,8 +120,14 @@ public:
    * @param expanded_nodes Expanded node to clean up from search
    */
   void cleanNode(const NodePtr & nodes);
+
+  /**
+   * @brief Used to limit the planner to explore ahead of the specified pose
+   * @param search_bounds the pose beyoind which we want to limit the planner
+   * @param allow_goal_overshoot to set the value of this param
+   * @param is_start_behind_goal this is required because we want to allow searching on the side of the goal where the start pose is
+   */
   void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal);
-  void clearSearchBounds();
 
 protected:
   MotionModel _motion_model;

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -20,6 +20,7 @@
 #include <list>
 #include <memory>
 
+#include "geometry_msgs/Point.h"
 #include "smac_planner/node_2d.hpp"
 #include "smac_planner/node_hybrid.hpp"
 #include "smac_planner/node_lattice.hpp"
@@ -123,10 +124,10 @@ public:
   /**
    * @brief Used to limit the planner to explore ahead of the specified pose
    * @param search_bounds the pose beyoind which we want to limit the planner
-   * @param allow_goal_overshoot to set the value of this param
-   * @param is_start_behind_goal this is required because we want to allow searching on the side of the goal where the start pose is
+   * @param start_point the start point
+   * @param allow_goal_overshoot enable/disable this feature
    */
-  void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal);
+  void setSearchBounds(const geometry_msgs::Pose &search_bounds, const geometry_msgs::Point& start_point, bool allow_goal_overshoot);
 
 protected:
   MotionModel _motion_model;

--- a/include/smac_planner/analytic_expansion.hpp
+++ b/include/smac_planner/analytic_expansion.hpp
@@ -119,7 +119,7 @@ public:
    * @param expanded_nodes Expanded node to clean up from search
    */
   void cleanNode(const NodePtr & nodes);
-  void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds);
+  void setSearchBounds(const geometry_msgs::PoseStamped &search_bounds, bool behind);
   void clearSearchBounds();
 
 protected:

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -106,7 +106,7 @@ protected:
   double _angle_bin_size;
   unsigned int _angle_quantizations;
   SearchInfo _search_info;
-  bool _allow_goal_overshoot = false;
+  bool _allow_goal_overshoot = true;
   bool _planning_canceled;
   MotionModel _motion_model;
   ros::Publisher _raw_plan_publisher;

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -92,6 +92,8 @@ protected:
    */
   void reconfigureCB(SmacPlannerHybridConfig& config, uint32_t level);
 
+  bool checkIfPoseBelowPose(const geometry_msgs::PoseStamped& start_pose, const geometry_msgs::PoseStamped& goal_pose);
+
   std::unique_ptr<dynamic_reconfigure::Server<SmacPlannerHybridConfig>> dsrv_;
 
   std::unique_ptr<AStarAlgorithm<NodeHybrid>> _a_star;

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -106,7 +106,6 @@ protected:
   double _angle_bin_size;
   unsigned int _angle_quantizations;
   SearchInfo _search_info;
-  bool _allow_goal_overshoot = true;
   bool _planning_canceled;
   MotionModel _motion_model;
   ros::Publisher _raw_plan_publisher;

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -112,6 +112,7 @@ protected:
   ros::Publisher _final_plan_publisher;
   ros::Publisher _planned_footprints_publisher;
   ros::Publisher _expansions_publisher;
+  bool _set_search_bounds = false;
   std::mutex _mutex;
 };
 

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -92,8 +92,6 @@ protected:
    */
   void reconfigureCB(SmacPlannerHybridConfig& config, uint32_t level);
 
-  bool checkIfPoseBelowPose(const geometry_msgs::PoseStamped& start_pose, const geometry_msgs::PoseStamped& goal_pose);
-
   std::unique_ptr<dynamic_reconfigure::Server<SmacPlannerHybridConfig>> dsrv_;
 
   std::unique_ptr<AStarAlgorithm<NodeHybrid>> _a_star;

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -106,6 +106,7 @@ protected:
   double _angle_bin_size;
   unsigned int _angle_quantizations;
   SearchInfo _search_info;
+  bool _disable_goal_overshoot = false;
   bool _planning_canceled;
   MotionModel _motion_model;
   ros::Publisher _raw_plan_publisher;

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -106,7 +106,7 @@ protected:
   double _angle_bin_size;
   unsigned int _angle_quantizations;
   SearchInfo _search_info;
-  bool _disable_goal_overshoot = false;
+  bool _allow_goal_overshoot = false;
   bool _planning_canceled;
   MotionModel _motion_model;
   ros::Publisher _raw_plan_publisher;

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -112,7 +112,6 @@ protected:
   ros::Publisher _final_plan_publisher;
   ros::Publisher _planned_footprints_publisher;
   ros::Publisher _expansions_publisher;
-  bool _set_search_bounds = false;
   std::mutex _mutex;
 };
 

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -50,7 +50,7 @@ struct SearchInfo
   bool allow_primitive_interpolation{false};
   bool downsample_obstacle_heuristic{true};
   bool use_quadratic_cost_penalty{false};
-  std::optional<geometry_msgs::PoseStamped> search_bounds;
+  std::pair<std::optional<geometry_msgs::PoseStamped>, bool> search_bounds; // bool = true means behind the goal pose, bool = false means front of the goal pose
 };
 
 /**

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -15,12 +15,11 @@
 #ifndef SMAC_PLANNER__TYPES_HPP_
 #define SMAC_PLANNER__TYPES_HPP_
 
-#include <stdexcept>
 #include <vector>
 #include <utility>
 #include <string>
-#include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <optional>
 
 namespace smac_planner
 {

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -15,9 +15,11 @@
 #ifndef SMAC_PLANNER__TYPES_HPP_
 #define SMAC_PLANNER__TYPES_HPP_
 
+#include <stdexcept>
 #include <vector>
 #include <utility>
 #include <string>
+#include "geometry_msgs/Point.h"
 #include <geometry_msgs/PoseStamped.h>
 
 namespace smac_planner
@@ -49,8 +51,15 @@ struct SearchInfo
   bool allow_goal_overshoot{true};
   bool downsample_obstacle_heuristic{true};
   bool use_quadratic_cost_penalty{false};
-  bool is_start_behind_goal;
-  geometry_msgs::PoseStamped search_bounds;
+  void setStart(const geometry_msgs::Point& start);
+  geometry_msgs::Pose getSearchBound();
+  void setSearchBound(const geometry_msgs::Pose& search_bound);
+  bool isStartBehindSearchBounds();
+
+private:
+  geometry_msgs::Point _start_pose;
+  geometry_msgs::Pose _search_bound;
+  std::optional<bool> is_start_behind_goal;
 };
 
 /**

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <memory>
 #include <optional>
-#include "geometry_msgs/PoseStamped.h"
+#include <geometry_msgs/PoseStamped.h>
 
 namespace smac_planner
 {
@@ -50,7 +50,8 @@ struct SearchInfo
   bool allow_primitive_interpolation{false};
   bool downsample_obstacle_heuristic{true};
   bool use_quadratic_cost_penalty{false};
-  std::pair<std::optional<geometry_msgs::PoseStamped>, bool> search_bounds; // bool = true means behind the goal pose, bool = false means front of the goal pose
+  std::optional<geometry_msgs::PoseStamped> search_bounds;
+  geometry_msgs::PoseStamped start_pose;
 };
 
 /**

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -19,7 +19,8 @@
 #include <utility>
 #include <string>
 #include <memory>
-
+#include <optional>
+#include "geometry_msgs/PoseStamped.h"
 
 namespace smac_planner
 {
@@ -49,6 +50,7 @@ struct SearchInfo
   bool allow_primitive_interpolation{false};
   bool downsample_obstacle_heuristic{true};
   bool use_quadratic_cost_penalty{false};
+  std::optional<geometry_msgs::PoseStamped> search_bounds;
 };
 
 /**

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -18,8 +18,6 @@
 #include <vector>
 #include <utility>
 #include <string>
-#include <memory>
-#include <optional>
 #include <geometry_msgs/PoseStamped.h>
 
 namespace smac_planner

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <utility>
 #include <string>
-#include "geometry_msgs/Point.h"
+#include <geometry_msgs/Point.h>
 #include <geometry_msgs/PoseStamped.h>
 
 namespace smac_planner

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -48,10 +48,10 @@ struct SearchInfo
   bool cache_obstacle_heuristic{false};
   bool allow_reverse_expansion{false};
   bool allow_primitive_interpolation{false};
+  bool allow_goal_overshoot{true};
   bool downsample_obstacle_heuristic{true};
   bool use_quadratic_cost_penalty{false};
-  std::optional<geometry_msgs::PoseStamped> search_bounds;
-  geometry_msgs::PoseStamped start_pose;
+  geometry_msgs::PoseStamped search_bounds;
 };
 
 /**

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -49,6 +49,7 @@ struct SearchInfo
   bool allow_goal_overshoot{true};
   bool downsample_obstacle_heuristic{true};
   bool use_quadratic_cost_penalty{false};
+  bool is_start_behind_goal;
   geometry_msgs::PoseStamped search_bounds;
 };
 

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -54,6 +54,36 @@ public:
   }
 
   /**
+  * @brief Check if the position of given x,y point is below or above the pose
+  * @param x float of X coordinate
+  * @param y float of Y coordinate
+  * @param reference_pose the pose with respect to which we want to check the position of the x,y point
+  * @return Bool true means point is below pose, false means point is above pose
+  */
+  static inline bool checkIfPointBelowPose(
+    const float & x,
+    const float & y,
+    const geometry_msgs::PoseStamped & reference_pose){
+
+      tf2::Quaternion q(
+        reference_pose.pose.orientation.x,
+        reference_pose.pose.orientation.y,
+        reference_pose.pose.orientation.z,
+        reference_pose.pose.orientation.w);
+      double roll, pitch, yaw;
+      tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+
+      float dx = std::cos(yaw);
+      float dy = std::sin(yaw);
+
+      float vx = x - reference_pose.pose.position.x;
+      float vy = y - reference_pose.pose.position.y;
+
+      float dot = vx * dx + vy * dy;
+      return (dot < 0);
+    }
+
+  /**
   * @brief Create quaternion from radians
   * @param theta continuous bin coordinates angle
   * @return quaternion orientation in map frame

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -65,18 +65,18 @@ public:
     const geometry_msgs::Pose & reference_pose){
 
       tf2::Quaternion q(
-        reference_pose.pose.orientation.x,
-        reference_pose.pose.orientation.y,
-        reference_pose.pose.orientation.z,
-        reference_pose.pose.orientation.w);
+        reference_pose.orientation.x,
+        reference_pose.orientation.y,
+        reference_pose.orientation.z,
+        reference_pose.orientation.w);
       double roll, pitch, yaw;
       tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
 
       float dx = std::cos(yaw);
       float dy = std::sin(yaw);
 
-      float vx = pose.position.x - reference_pose.pose.position.x;
-      float vy = pose.position.y - reference_pose.pose.position.y;
+      float vx = point.x - reference_pose.position.x;
+      float vy = point.y - reference_pose.position.y;
 
       float dot = vx * dx + vy * dy;
       return (dot < 0);

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -60,9 +60,8 @@ public:
   * @param reference_pose the pose with respect to which we want to check the position of the x,y point
   * @return Bool true means point is below pose, false means point is above pose
   */
-  static inline bool checkIfPointBelowPose(
-    const float & x,
-    const float & y,
+  static inline bool isBehindPose(
+    const geometry_msgs::Pose & pose,
     const geometry_msgs::PoseStamped & reference_pose){
 
       tf2::Quaternion q(
@@ -76,8 +75,8 @@ public:
       float dx = std::cos(yaw);
       float dy = std::sin(yaw);
 
-      float vx = x - reference_pose.pose.position.x;
-      float vy = y - reference_pose.pose.position.y;
+      float vx = pose.position.x - reference_pose.pose.position.x;
+      float vy = pose.position.y - reference_pose.pose.position.y;
 
       float dot = vx * dx + vy * dy;
       return (dot < 0);

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -21,7 +21,6 @@
 #include <string>
 
 #include "nlohmann/json.hpp"
-#include "Eigen/Core"
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Pose.h"
 #include "tf2/utils.h"

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 
+#include "geometry_msgs/Point.h"
 #include "nlohmann/json.hpp"
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Pose.h"
@@ -60,8 +61,8 @@ public:
   * @return Bool true means point is below pose, false means point is above pose
   */
   static inline bool isBehindPose(
-    const geometry_msgs::Pose & pose,
-    const geometry_msgs::PoseStamped & reference_pose){
+    const geometry_msgs::Point & point,
+    const geometry_msgs::Pose & reference_pose){
 
       tf2::Quaternion q(
         reference_pose.pose.orientation.x,

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -55,8 +55,7 @@ public:
 
   /**
   * @brief Check if the position of given x,y point is below or above the pose
-  * @param x float of X coordinate
-  * @param y float of Y coordinate
+  * @param point the point whose position we want to check with respect to the reference_pose
   * @param reference_pose the pose with respect to which we want to check the position of the x,y point
   * @return Bool true means point is below pose, false means point is above pose
   */

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 
-#include "geometry_msgs/Point.h"
+#include <geometry_msgs/Point.h>
 #include "nlohmann/json.hpp"
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Pose.h"

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -24,8 +24,7 @@
 
 
 #include <geometry_msgs/Pose.h>
-#include "geometry_msgs/Point.h"
-#include "geometry_msgs/PoseStamped.h"
+#include <geometry_msgs/Point.h>
 #include "mbf_msgs/GetPathResult.h"
 #include "smac_planner/utils.hpp"
 

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -125,7 +125,7 @@ void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& se
 {
   _search_info.search_bounds = search_bounds;
   _search_info.allow_goal_overshoot = allow_goal_overshoot;
-  _is_start_behind_goal = is_start_behind_goal;
+  _search_info.is_start_behind_goal =  is_start_behind_goal;
   _expander->setSearchBounds(search_bounds, allow_goal_overshoot, is_start_behind_goal);
 }
 
@@ -334,7 +334,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (!_search_info.allow_goal_overshoot){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-               if (isNodeBelowPose(&(iter->second), _search_info.search_bounds) != _is_start_behind_goal){
+               if (isNodeBelowPose(&(iter->second), _search_info.search_bounds) != _search_info.is_start_behind_goal){
                 return false;
                }
             }
@@ -405,7 +405,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       neighbor = *neighbor_iterator;
 
       if (!_search_info.allow_goal_overshoot) {
-        if ((isNodeBelowPose(neighbor, _search_info.search_bounds)) != _is_start_behind_goal) {
+        if ((isNodeBelowPose(neighbor, _search_info.search_bounds)) != _search_info.is_start_behind_goal) {
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -428,10 +428,6 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
             return false;
         }
       }
-
-      else{
-        ROS_ERROR("FAIL AGAIN");
-      }
       neighbor_rtn = addToGraph(index);
       return true;
     };
@@ -452,7 +448,6 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     current_node = getNextNode();
     std::vector<float> goal_vector {_goal_coordinates.x, _goal_coordinates.y};
     float distance = getDistanceToGoal(current_node, goal_vector);
-    ROS_ERROR("\n\n\nDistance to Goal: %.2f\n\n\n", distance);
 
     // Save current node coordinates for debug
     if (expansions_log) {
@@ -502,14 +497,9 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
 
       if (_search_info.search_bounds) {
         if (!checkNodeBelowPose(neighbor, * _search_info.search_bounds)) {
-          ROS_ERROR("value set");
           // Skip this neighbor, it's not "below" the search bounds pose
           continue;
         }
-      }
-
-      else{
-        ROS_ERROR("FAIL AGAIN AGAIN");
       }
 
       // 4.1) Compute the cost to go to this node

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -185,23 +185,23 @@ void AStarAlgorithm<Node2D>::populateExpansionsLog(
 }
 
 template<>
-bool AStarAlgorithm<Node2D>::isNodeBelowPose(
+bool AStarAlgorithm<Node2D>::isBehindPose(
   const NodePtr & node,
-  const geometry_msgs::PoseStamped & pose)
+  const geometry_msgs::Pose & pose)
 {
   const Node2D::Coordinates node_coords = node->getCoords(node->getIndex());
   const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
-  return Utils::isBehindPose(node_in_world_frame.position, pose.pose);
+  return Utils::isBehindPose(node_in_world_frame.position, pose);
 }
 
 template<typename NodeT>
-bool AStarAlgorithm<NodeT>::isNodeBelowPose(
+bool AStarAlgorithm<NodeT>::isBehindPose(
   const NodePtr & node,
-  const geometry_msgs::PoseStamped & pose)
+  const geometry_msgs::Pose & pose)
 {
   typename NodeT::Coordinates node_coords = node->pose;
   const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
-  return Utils::isBehindPose(node_in_world_frame.position, pose.pose);
+  return Utils::isBehindPose(node_in_world_frame.position, pose);
 }
 
 template<typename NodeT>
@@ -334,7 +334,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (!_search_info.allow_goal_overshoot){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-               if (isNodeBelowPose(&(iter->second), _search_info.search_bounds) != _search_info.is_start_behind_goal){
+               if (isBehindPose(&(iter->second), _search_info.search_bounds.pose) != _search_info.is_start_behind_goal){
                 return false;
                }
             }
@@ -405,7 +405,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       neighbor = *neighbor_iterator;
 
       if (!_search_info.allow_goal_overshoot) {
-        if ((isNodeBelowPose(neighbor, _search_info.search_bounds)) != _search_info.is_start_behind_goal) {
+        if ((isBehindPose(neighbor, _search_info.search_bounds.pose)) != _search_info.is_start_behind_goal) {
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -411,8 +411,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
 
     // 1) Pick Nbest from O s.t. min(f(Nbest)), remove from queue
     current_node = getNextNode();
-    std::vector<float> goal_vector {_goal_coordinates.x, _goal_coordinates.y};
-
+  
     // Save current node coordinates for debug
     if (expansions_log) {
       populateExpansionsLog(current_node, expansions_log);

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -477,7 +477,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
 
       if (_search_info.search_bounds.first && !_search_info.search_bounds.second) {
         if (checkNodeBelowPose(neighbor, * _search_info.search_bounds.first)) {
-          // Skip this neighbor, it's not "below" the search bounds pose
+          // Skip this neighbor, it's "below" the search bounds pose
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -191,9 +191,9 @@ bool AStarAlgorithm<Node2D>::checkNodeBelowPose(
   const NodePtr & node,
   const geometry_msgs::PoseStamped & pose)
 {
-  Node2D::Coordinates node_coords = node->getCoords(node->getIndex());
-  geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
-  return Utils::checkIfPointBelowPose(node_in_world_frame.position.x, node_in_world_frame.position.y, pose);
+  const Node2D::Coordinates node_coords = node->getCoords(node->getIndex());
+  const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
+  return Utils::isBehindPose(node_in_world_frame, pose);
 }
 
 template<typename NodeT>
@@ -202,8 +202,8 @@ bool AStarAlgorithm<NodeT>::checkNodeBelowPose(
   const geometry_msgs::PoseStamped & pose)
 {
   typename NodeT::Coordinates node_coords = node->pose;
-  geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
-  return Utils::checkIfPointBelowPose(node_in_world_frame.position.x, node_in_world_frame.position.y, pose);
+  const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
+  return Utils::isBehindPose(node_in_world_frame, pose);
 }
 
 template<typename NodeT>

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -119,16 +119,17 @@ void AStarAlgorithm<NodeT>::setCollisionChecker(GridCollisionChecker * collision
 }
 
 template <typename NodeT>
-void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds)
+void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, bool behind)
 {
-  _search_info.search_bounds = search_bounds;
-  _expander->setSearchBounds(search_bounds);
+  _search_info.search_bounds.first = search_bounds;
+  _search_info.search_bounds.second = behind;
+  _expander->setSearchBounds(search_bounds, behind);
 }
 
 template <typename NodeT>
 void AStarAlgorithm<NodeT>::clearSearchBounds()
 {
-  _search_info.search_bounds.reset();
+  _search_info.search_bounds.first.reset();
   _expander->clearSearchBounds();
 }
 
@@ -386,11 +387,20 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (index >= max_index) {
         return false;
       }
-      if (_search_info.search_bounds.has_value()){
+      if (_search_info.search_bounds.first.has_value()){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-          if (checkNodeBelowPose(&(iter->second), * _search_info.search_bounds))
-            return false;
+          if (_search_info.search_bounds.second){
+            if (checkNodeBelowPose(&(iter->second), * _search_info.search_bounds.first)){
+              return false;
+            }
+          }
+          else{
+            if (!checkNodeBelowPose(&(iter->second), * _search_info.search_bounds.first)){
+              return false;
+            }
+          }
+
         }
       }
       neighbor_rtn = addToGraph(index);
@@ -411,7 +421,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
 
     // 1) Pick Nbest from O s.t. min(f(Nbest)), remove from queue
     current_node = getNextNode();
-  
+
     // Save current node coordinates for debug
     if (expansions_log) {
       populateExpansionsLog(current_node, expansions_log);
@@ -458,8 +468,15 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     {
       neighbor = *neighbor_iterator;
 
-      if (_search_info.search_bounds) {
-        if (!checkNodeBelowPose(neighbor, * _search_info.search_bounds)) {
+      if (_search_info.search_bounds.first && _search_info.search_bounds.second) {
+        if (!checkNodeBelowPose(neighbor, * _search_info.search_bounds.first)) {
+          // Skip this neighbor, it's not "below" the search bounds pose
+          continue;
+        }
+      }
+
+      if (_search_info.search_bounds.first && !_search_info.search_bounds.second) {
+        if (checkNodeBelowPose(neighbor, * _search_info.search_bounds.first)) {
           // Skip this neighbor, it's not "below" the search bounds pose
           continue;
         }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -121,7 +121,16 @@ void AStarAlgorithm<NodeT>::setCollisionChecker(GridCollisionChecker * collision
 template <typename NodeT>
 void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds)
 {
-  _search_bounds = search_bounds;
+  _search_info.search_bounds = search_bounds;
+  _expander->setSearchBounds(search_bounds);
+  ROS_WARN("\n\n\n\n\n\n\n\n\n\n\n\n\n\nSET SEARCH BOUNDS CALLED!!!!!!\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+}
+
+template <typename NodeT>
+void AStarAlgorithm<NodeT>::clearSearchBounds()
+{
+  _search_info.search_bounds.reset();
+  _expander->clearSearchBounds();
 }
 
 
@@ -412,13 +421,16 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (index >= max_index) {
         return false;
       }
-      if (_search_bounds.has_value()){
+      if (_search_info.search_bounds.has_value()){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-          if (checkNodeBelowPose(&(iter->second), * _search_bounds))
-            ROS_ERROR("SKIPPED");
+          if (checkNodeBelowPose(&(iter->second), * _search_info.search_bounds))
             return false;
         }
+      }
+
+      else{
+        ROS_ERROR("FAIL AGAIN");
       }
       neighbor_rtn = addToGraph(index);
       return true;
@@ -488,11 +500,16 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     {
       neighbor = *neighbor_iterator;
 
-      if (_search_bounds) {
-        if (!checkNodeBelowPose(neighbor, *_search_bounds)) {
+      if (_search_info.search_bounds) {
+        if (!checkNodeBelowPose(neighbor, * _search_info.search_bounds)) {
+          ROS_ERROR("value set");
           // Skip this neighbor, it's not "below" the search bounds pose
           continue;
         }
+      }
+
+      else{
+        ROS_ERROR("FAIL AGAIN AGAIN");
       }
 
       // 4.1) Compute the cost to go to this node

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+
 #include "mbf_msgs/GetPathResult.h"
 
 #include "smac_planner/a_star.hpp"
@@ -119,17 +120,17 @@ void AStarAlgorithm<NodeT>::setCollisionChecker(GridCollisionChecker * collision
 }
 
 template <typename NodeT>
-void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, bool behind)
+void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds,const geometry_msgs::PoseStamped& start)
 {
-  _search_info.search_bounds.first = search_bounds;
-  _search_info.search_bounds.second = behind;
-  _expander->setSearchBounds(search_bounds, behind);
+  _search_info.search_bounds = search_bounds;
+  _search_info.start_pose = start;
+  _expander->setSearchBounds(search_bounds, start);
 }
 
 template <typename NodeT>
 void AStarAlgorithm<NodeT>::clearSearchBounds()
 {
-  _search_info.search_bounds.first.reset();
+  _search_info.search_bounds.reset();
   _expander->clearSearchBounds();
 }
 
@@ -193,32 +194,9 @@ bool AStarAlgorithm<Node2D>::checkNodeBelowPose(
   const NodePtr & node,
   const geometry_msgs::PoseStamped & pose)
 {
-  // Use getCoords for Node2D
-  Node2D::Coordinates coords = node->getCoords(node->getIndex());
-
-  float node_x = _costmap->getOriginX() + ((coords.x + 0.5f) * _costmap->getResolution());
-  float node_y = _costmap->getOriginY() + ((coords.y + 0.5f) * _costmap->getResolution());
-
-  float pose_x = pose.pose.position.x;
-  float pose_y = pose.pose.position.y;
-
-  tf2::Quaternion q(
-    pose.pose.orientation.x,
-    pose.pose.orientation.y,
-    pose.pose.orientation.z,
-    pose.pose.orientation.w);
-  double roll, pitch, yaw;
-  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
-
-  float dx = std::cos(yaw);
-  float dy = std::sin(yaw);
-
-  float vx = node_x - pose_x;
-  float vy = node_y - pose_y;
-
-  float dot = vx * dx + vy * dy;
-
-  return (dot < 0);
+  Node2D::Coordinates node_coords = node->getCoords(node->getIndex());
+  geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
+  return Utils::checkIfPointBelowPose(node_in_world_frame.position.x, node_in_world_frame.position.y, pose);
 }
 
 template<typename NodeT>
@@ -226,39 +204,9 @@ bool AStarAlgorithm<NodeT>::checkNodeBelowPose(
   const NodePtr & node,
   const geometry_msgs::PoseStamped & pose)
 {
-  // Get node grid coordinates (assuming node has getCoords/getIndex method)
-  typename NodeT::Coordinates coords = node->pose;
-
-  // Convert node grid cell to world coordinates (meters)
-  float node_x = _costmap->getOriginX() + ((coords.x + 0.5f) * _costmap->getResolution());
-  float node_y = _costmap->getOriginY() + ((coords.y + 0.5f) * _costmap->getResolution());
-
-  // Extract pose position and yaw (orientation in radians)
-  float pose_x = pose.pose.position.x;
-  float pose_y = pose.pose.position.y;
-
-  // Convert quaternion to yaw (assuming pose.orientation is a quaternion)
-  tf2::Quaternion q(
-    pose.pose.orientation.x,
-    pose.pose.orientation.y,
-    pose.pose.orientation.z,
-    pose.pose.orientation.w);
-  double roll, pitch, yaw;
-  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
-
-  // Direction vector of pose (facing direction)
-  float dx = std::cos(yaw);
-  float dy = std::sin(yaw);
-
-  // Vector from pose to node
-  float vx = node_x - pose_x;
-  float vy = node_y - pose_y;
-
-  // Dot product to check if node is behind the perpendicular
-  float dot = vx * dx + vy * dy;
-
-  // If dot < 0, node is behind pose’s perpendicular line
-  return (dot < 0);
+  typename NodeT::Coordinates node_coords = node->pose;
+  geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
+  return Utils::checkIfPointBelowPose(node_in_world_frame.position.x, node_in_world_frame.position.y, pose);
 }
 
 template<typename NodeT>
@@ -379,6 +327,10 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
   int analytic_iterations = 0;
   int closest_distance = std::numeric_limits<int>::max();
 
+  bool is_start_behind_goal;
+  if (_search_info.search_bounds.has_value()){
+    is_start_behind_goal = Utils::checkIfPointBelowPose(_search_info.start_pose.pose.position.x, _search_info.start_pose.pose.position.y, _search_info.search_bounds.value());
+  }
   // Given an index, return a node ptr reference if its collision-free and valid
   const unsigned int max_index = getSizeX() * getSizeY() * getSizeDim3();
   NodeGetter neighborGetter =
@@ -387,22 +339,14 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (index >= max_index) {
         return false;
       }
-      if (_search_info.search_bounds.first.has_value()){
+      if (_search_info.search_bounds.has_value()){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-          if (_search_info.search_bounds.second){
-            if (checkNodeBelowPose(&(iter->second), * _search_info.search_bounds.first)){
-              return false;
+               if (checkNodeBelowPose(&(iter->second), * _search_info.search_bounds) != is_start_behind_goal){
+                return false;
+               }
             }
-          }
-          else{
-            if (!checkNodeBelowPose(&(iter->second), * _search_info.search_bounds.first)){
-              return false;
-            }
-          }
-
         }
-      }
       neighbor_rtn = addToGraph(index);
       return true;
     };
@@ -418,7 +362,6 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
         return mbf_msgs::GetPathResult::PAT_EXCEEDED;
       }
     }
-
     // 1) Pick Nbest from O s.t. min(f(Nbest)), remove from queue
     current_node = getNextNode();
 
@@ -468,16 +411,8 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     {
       neighbor = *neighbor_iterator;
 
-      if (_search_info.search_bounds.first && _search_info.search_bounds.second) {
-        if (!checkNodeBelowPose(neighbor, * _search_info.search_bounds.first)) {
-          // Skip this neighbor, it's not "below" the search bounds pose
-          continue;
-        }
-      }
-
-      if (_search_info.search_bounds.first && !_search_info.search_bounds.second) {
-        if (checkNodeBelowPose(neighbor, * _search_info.search_bounds.first)) {
-          // Skip this neighbor, it's "below" the search bounds pose
+      if (_search_info.search_bounds) {
+        if ((checkNodeBelowPose(neighbor, * _search_info.search_bounds)) != is_start_behind_goal) {
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -25,7 +25,9 @@
 #include <vector>
 
 
+#include "geometry_msgs/Pose.h"
 #include "mbf_msgs/GetPathResult.h"
+#include "smac_planner/utils.hpp"
 
 #include "smac_planner/a_star.hpp"
 
@@ -119,19 +121,14 @@ void AStarAlgorithm<NodeT>::setCollisionChecker(GridCollisionChecker * collision
   _expander->setCollisionChecker(_collision_checker);
 }
 
-template <typename NodeT>
-void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds,const geometry_msgs::PoseStamped& start)
-{
-  _search_info.search_bounds = search_bounds;
-  _search_info.start_pose = start;
-  _expander->setSearchBounds(search_bounds, start);
-}
 
 template <typename NodeT>
-void AStarAlgorithm<NodeT>::clearSearchBounds()
+void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal)
 {
-  _search_info.search_bounds.reset();
-  _expander->clearSearchBounds();
+  _search_info.search_bounds = search_bounds;
+  _search_info.allow_goal_overshoot = allow_goal_overshoot;
+  _is_start_behind_goal = is_start_behind_goal;
+  _expander->setSearchBounds(search_bounds, allow_goal_overshoot, is_start_behind_goal);
 }
 
 
@@ -327,10 +324,6 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
   int analytic_iterations = 0;
   int closest_distance = std::numeric_limits<int>::max();
 
-  bool is_start_behind_goal;
-  if (_search_info.search_bounds.has_value()){
-    is_start_behind_goal = Utils::checkIfPointBelowPose(_search_info.start_pose.pose.position.x, _search_info.start_pose.pose.position.y, _search_info.search_bounds.value());
-  }
   // Given an index, return a node ptr reference if its collision-free and valid
   const unsigned int max_index = getSizeX() * getSizeY() * getSizeDim3();
   NodeGetter neighborGetter =
@@ -339,10 +332,10 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (index >= max_index) {
         return false;
       }
-      if (_search_info.search_bounds.has_value()){
+      if (!_search_info.allow_goal_overshoot){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-               if (checkNodeBelowPose(&(iter->second), * _search_info.search_bounds) != is_start_behind_goal){
+               if (checkNodeBelowPose(&(iter->second), _search_info.search_bounds) != _is_start_behind_goal){
                 return false;
                }
             }
@@ -411,8 +404,8 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     {
       neighbor = *neighbor_iterator;
 
-      if (_search_info.search_bounds) {
-        if ((checkNodeBelowPose(neighbor, * _search_info.search_bounds)) != is_start_behind_goal) {
+      if (!_search_info.allow_goal_overshoot) {
+        if ((checkNodeBelowPose(neighbor, _search_info.search_bounds)) != _is_start_behind_goal) {
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 
-#include "geometry_msgs/Pose.h"
+#include <geometry_msgs/Pose.h>
 #include "mbf_msgs/GetPathResult.h"
 #include "smac_planner/utils.hpp"
 
@@ -191,7 +191,7 @@ bool AStarAlgorithm<Node2D>::checkNodeBelowPose(
 {
   const Node2D::Coordinates node_coords = node->getCoords(node->getIndex());
   const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
-  return Utils::isBehindPose(node_in_world_frame, pose);
+  return Utils::isBehindPose(node_in_world_frame.position, pose.pose);
 }
 
 template<typename NodeT>
@@ -201,7 +201,7 @@ bool AStarAlgorithm<NodeT>::checkNodeBelowPose(
 {
   typename NodeT::Coordinates node_coords = node->pose;
   const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
-  return Utils::isBehindPose(node_in_world_frame, pose);
+  return Utils::isBehindPose(node_in_world_frame.position, pose.pose);
 }
 
 template<typename NodeT>

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -185,7 +185,7 @@ void AStarAlgorithm<Node2D>::populateExpansionsLog(
 }
 
 template<>
-bool AStarAlgorithm<Node2D>::checkNodeBelowPose(
+bool AStarAlgorithm<Node2D>::isNodeBelowPose(
   const NodePtr & node,
   const geometry_msgs::PoseStamped & pose)
 {
@@ -195,7 +195,7 @@ bool AStarAlgorithm<Node2D>::checkNodeBelowPose(
 }
 
 template<typename NodeT>
-bool AStarAlgorithm<NodeT>::checkNodeBelowPose(
+bool AStarAlgorithm<NodeT>::isNodeBelowPose(
   const NodePtr & node,
   const geometry_msgs::PoseStamped & pose)
 {
@@ -334,7 +334,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (!_search_info.allow_goal_overshoot){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-               if (checkNodeBelowPose(&(iter->second), _search_info.search_bounds) != _is_start_behind_goal){
+               if (isNodeBelowPose(&(iter->second), _search_info.search_bounds) != _is_start_behind_goal){
                 return false;
                }
             }
@@ -405,7 +405,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       neighbor = *neighbor_iterator;
 
       if (!_search_info.allow_goal_overshoot) {
-        if ((checkNodeBelowPose(neighbor, _search_info.search_bounds)) != _is_start_behind_goal) {
+        if ((isNodeBelowPose(neighbor, _search_info.search_bounds)) != _is_start_behind_goal) {
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -19,8 +19,6 @@
 #include <memory>
 #include <algorithm>
 #include <limits>
-#include <type_traits>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -332,6 +330,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (index >= max_index) {
         return false;
       }
+
       if (!_search_info.allow_goal_overshoot){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
@@ -355,6 +354,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
         return mbf_msgs::GetPathResult::PAT_EXCEEDED;
       }
     }
+
     // 1) Pick Nbest from O s.t. min(f(Nbest)), remove from queue
     current_node = getNextNode();
 

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -24,6 +24,8 @@
 
 
 #include <geometry_msgs/Pose.h>
+#include "geometry_msgs/Point.h"
+#include "geometry_msgs/PoseStamped.h"
 #include "mbf_msgs/GetPathResult.h"
 #include "smac_planner/utils.hpp"
 
@@ -121,12 +123,12 @@ void AStarAlgorithm<NodeT>::setCollisionChecker(GridCollisionChecker * collision
 
 
 template <typename NodeT>
-void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal)
+void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::Pose& search_bounds, const geometry_msgs::Point& start_point, bool allow_goal_overshoot)
 {
-  _search_info.search_bounds = search_bounds;
+  _search_info.setSearchBound(search_bounds);
+  _search_info.setStart(start_point);
   _search_info.allow_goal_overshoot = allow_goal_overshoot;
-  _search_info.is_start_behind_goal =  is_start_behind_goal;
-  _expander->setSearchBounds(search_bounds, allow_goal_overshoot, is_start_behind_goal);
+  _expander->setSearchBounds(search_bounds, start_point, allow_goal_overshoot);
 }
 
 
@@ -321,6 +323,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
   NeighborIterator neighbor_iterator;
   int analytic_iterations = 0;
   int closest_distance = std::numeric_limits<int>::max();
+  const bool is_start_behind_goal = _search_info.isStartBehindSearchBounds();
 
   // Given an index, return a node ptr reference if its collision-free and valid
   const unsigned int max_index = getSizeX() * getSizeY() * getSizeDim3();
@@ -334,7 +337,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (!_search_info.allow_goal_overshoot){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-               if (isBehindPose(&(iter->second), _search_info.search_bounds.pose) != _search_info.is_start_behind_goal){
+               if (isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal){
                 return false;
                }
             }
@@ -405,7 +408,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       neighbor = *neighbor_iterator;
 
       if (!_search_info.allow_goal_overshoot) {
-        if ((isBehindPose(neighbor, _search_info.search_bounds.pose)) != _search_info.is_start_behind_goal) {
+        if ((isBehindPose(neighbor, _search_info.getSearchBound())) != is_start_behind_goal) {
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -123,7 +123,6 @@ void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& se
 {
   _search_info.search_bounds = search_bounds;
   _expander->setSearchBounds(search_bounds);
-  ROS_WARN("\n\n\n\n\n\n\n\n\n\n\n\n\n\nSET SEARCH BOUNDS CALLED!!!!!!\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
 }
 
 template <typename NodeT>

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -188,40 +188,6 @@ void AStarAlgorithm<Node2D>::populateExpansionsLog(
 }
 
 template<>
-float AStarAlgorithm<Node2D>::getDistanceToGoal(
-  const NodePtr & node,
-  std::vector<float> goal_pose)
-{
-  Node2D::Coordinates coords = node->getCoords(node->getIndex());
-  float node_x = _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution());
-  float node_y = _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution());
-  float goal_x = _costmap->getOriginX() + ((goal_pose[0] + 0.5) * _costmap->getResolution());
-  float goal_y = _costmap->getOriginY() + ((goal_pose[1] + 0.5) * _costmap->getResolution());
-
-
-  float dx = node_x - goal_x;
-  float dy = node_y - goal_y;
-
-  return std::sqrt(dx * dx + dy * dy);
-}
-
-template<typename NodeT>
-float AStarAlgorithm<NodeT>::getDistanceToGoal(
-  const NodePtr & node,
-  std::vector<float> goal_pose)
-{
-  typename NodeT::Coordinates coords = node->pose;
-  float goal_x = _costmap->getOriginX() + ((goal_pose[0] + 0.5) * _costmap->getResolution());
-  float goal_y = _costmap->getOriginY() + ((goal_pose[1] + 0.5) * _costmap->getResolution());
-  float node_x = _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution());
-  float node_y = _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution());
-  float dx = node_x - goal_x;
-  float dy = node_y - goal_y;
-
-  return std::sqrt(dx * dx + dy * dy);
-}
-
-template<>
 bool AStarAlgorithm<Node2D>::checkNodeBelowPose(
   const NodePtr & node,
   const geometry_msgs::PoseStamped & pose)
@@ -446,7 +412,6 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     // 1) Pick Nbest from O s.t. min(f(Nbest)), remove from queue
     current_node = getNextNode();
     std::vector<float> goal_vector {_goal_coordinates.x, _goal_coordinates.y};
-    float distance = getDistanceToGoal(current_node, goal_vector);
 
     // Save current node coordinates for debug
     if (expansions_log) {

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -118,6 +118,13 @@ void AStarAlgorithm<NodeT>::setCollisionChecker(GridCollisionChecker * collision
   _expander->setCollisionChecker(_collision_checker);
 }
 
+template <typename NodeT>
+void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::PoseStamped& search_bounds)
+{
+  _search_bounds = search_bounds;
+}
+
+
 template<typename NodeT>
 typename AStarAlgorithm<NodeT>::NodePtr AStarAlgorithm<NodeT>::addToGraph(
   const unsigned int & index)
@@ -170,6 +177,113 @@ void AStarAlgorithm<Node2D>::populateExpansionsLog(
     _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution()),
     _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution()),
     0.0);
+}
+
+template<>
+float AStarAlgorithm<Node2D>::getDistanceToGoal(
+  const NodePtr & node,
+  std::vector<float> goal_pose)
+{
+  Node2D::Coordinates coords = node->getCoords(node->getIndex());
+  float node_x = _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution());
+  float node_y = _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution());
+  float goal_x = _costmap->getOriginX() + ((goal_pose[0] + 0.5) * _costmap->getResolution());
+  float goal_y = _costmap->getOriginY() + ((goal_pose[1] + 0.5) * _costmap->getResolution());
+
+
+  float dx = node_x - goal_x;
+  float dy = node_y - goal_y;
+
+  return std::sqrt(dx * dx + dy * dy);
+}
+
+template<typename NodeT>
+float AStarAlgorithm<NodeT>::getDistanceToGoal(
+  const NodePtr & node,
+  std::vector<float> goal_pose)
+{
+  typename NodeT::Coordinates coords = node->pose;
+  float goal_x = _costmap->getOriginX() + ((goal_pose[0] + 0.5) * _costmap->getResolution());
+  float goal_y = _costmap->getOriginY() + ((goal_pose[1] + 0.5) * _costmap->getResolution());
+  float node_x = _costmap->getOriginX() + ((coords.x + 0.5) * _costmap->getResolution());
+  float node_y = _costmap->getOriginY() + ((coords.y + 0.5) * _costmap->getResolution());
+  float dx = node_x - goal_x;
+  float dy = node_y - goal_y;
+
+  return std::sqrt(dx * dx + dy * dy);
+}
+
+template<>
+bool AStarAlgorithm<Node2D>::checkNodeBelowPose(
+  const NodePtr & node,
+  const geometry_msgs::PoseStamped & pose)
+{
+  // Use getCoords for Node2D
+  Node2D::Coordinates coords = node->getCoords(node->getIndex());
+
+  float node_x = _costmap->getOriginX() + ((coords.x + 0.5f) * _costmap->getResolution());
+  float node_y = _costmap->getOriginY() + ((coords.y + 0.5f) * _costmap->getResolution());
+
+  float pose_x = pose.pose.position.x;
+  float pose_y = pose.pose.position.y;
+
+  tf2::Quaternion q(
+    pose.pose.orientation.x,
+    pose.pose.orientation.y,
+    pose.pose.orientation.z,
+    pose.pose.orientation.w);
+  double roll, pitch, yaw;
+  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+
+  float dx = std::cos(yaw);
+  float dy = std::sin(yaw);
+
+  float vx = node_x - pose_x;
+  float vy = node_y - pose_y;
+
+  float dot = vx * dx + vy * dy;
+
+  return (dot < 0);
+}
+
+template<typename NodeT>
+bool AStarAlgorithm<NodeT>::checkNodeBelowPose(
+  const NodePtr & node,
+  const geometry_msgs::PoseStamped & pose)
+{
+  // Get node grid coordinates (assuming node has getCoords/getIndex method)
+  typename NodeT::Coordinates coords = node->pose;
+
+  // Convert node grid cell to world coordinates (meters)
+  float node_x = _costmap->getOriginX() + ((coords.x + 0.5f) * _costmap->getResolution());
+  float node_y = _costmap->getOriginY() + ((coords.y + 0.5f) * _costmap->getResolution());
+
+  // Extract pose position and yaw (orientation in radians)
+  float pose_x = pose.pose.position.x;
+  float pose_y = pose.pose.position.y;
+
+  // Convert quaternion to yaw (assuming pose.orientation is a quaternion)
+  tf2::Quaternion q(
+    pose.pose.orientation.x,
+    pose.pose.orientation.y,
+    pose.pose.orientation.z,
+    pose.pose.orientation.w);
+  double roll, pitch, yaw;
+  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+
+  // Direction vector of pose (facing direction)
+  float dx = std::cos(yaw);
+  float dy = std::sin(yaw);
+
+  // Vector from pose to node
+  float vx = node_x - pose_x;
+  float vy = node_y - pose_y;
+
+  // Dot product to check if node is behind the perpendicular
+  float dot = vx * dx + vy * dy;
+
+  // If dot < 0, node is behind pose’s perpendicular line
+  return (dot < 0);
 }
 
 template<typename NodeT>
@@ -298,7 +412,14 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (index >= max_index) {
         return false;
       }
-
+      if (_search_bounds.has_value()){
+        auto iter = _graph.find(index);
+        if (iter != _graph.end()) {
+          if (checkNodeBelowPose(&(iter->second), * _search_bounds))
+            ROS_ERROR("SKIPPED");
+            return false;
+        }
+      }
       neighbor_rtn = addToGraph(index);
       return true;
     };
@@ -317,6 +438,9 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
 
     // 1) Pick Nbest from O s.t. min(f(Nbest)), remove from queue
     current_node = getNextNode();
+    std::vector<float> goal_vector {_goal_coordinates.x, _goal_coordinates.y};
+    float distance = getDistanceToGoal(current_node, goal_vector);
+    ROS_ERROR("\n\n\nDistance to Goal: %.2f\n\n\n", distance);
 
     // Save current node coordinates for debug
     if (expansions_log) {
@@ -363,6 +487,13 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       neighbor_iterator != neighbors.end(); ++neighbor_iterator)
     {
       neighbor = *neighbor_iterator;
+
+      if (_search_bounds) {
+        if (!checkNodeBelowPose(neighbor, *_search_bounds)) {
+          // Skip this neighbor, it's not "below" the search bounds pose
+          continue;
+        }
+      }
 
       // 4.1) Compute the cost to go to this node
       g_cost = current_node->getAccumulatedCost() + current_node->getTraversalCost(neighbor);

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -225,7 +225,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
 
     if (!_search_info.allow_goal_overshoot){
       geometry_msgs::Pose node_in_world_frame = Utils::getWorldCoords(reals[0], reals[1], _collision_checker->getCostmap());
-      bool is_node_behind_goal = Utils::isBehindPose(node_in_world_frame, _search_info.search_bounds);
+      bool is_node_behind_goal = Utils::isBehindPose(node_in_world_frame.position, _search_info.search_bounds.pose);
       if (is_node_behind_goal != _is_start_behind_goal){ // not equal means not on the same side
           failure = true;
           break;

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -48,18 +48,12 @@ void AnalyticExpansion<NodeT>::setCollisionChecker(
 
 template<typename NodeT>
 void AnalyticExpansion<NodeT>::setSearchBounds(
-  const geometry_msgs::PoseStamped &search_bounds, const geometry_msgs::PoseStamped& start)
+  const geometry_msgs::PoseStamped &search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal)
 {
   _search_info.search_bounds = search_bounds;
-  _search_info.start_pose = start;
+  _search_info.allow_goal_overshoot = allow_goal_overshoot;
+  _is_start_behind_goal = is_start_behind_goal;
 }
-
-template<typename NodeT>
-void AnalyticExpansion<NodeT>::clearSearchBounds()
-{
-  _search_info.search_bounds.reset();
-}
-
 
 template<typename NodeT>
 typename AnalyticExpansion<NodeT>::NodePtr AnalyticExpansion<NodeT>::tryAnalyticExpansion(
@@ -224,20 +218,14 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
   std::vector<float> node_costs;
   node_costs.reserve(num_intervals);
 
-  bool is_start_behind_goal;
-  if (_search_info.search_bounds.has_value()){
-    is_start_behind_goal = Utils::checkIfPointBelowPose(_search_info.start_pose.pose.position.x, _search_info.start_pose.pose.position.y, _search_info.search_bounds.value());
-  }
-
   for (float i = 1; i < num_intervals; i++) {
     state_space->interpolate(from(), to(), i / num_intervals, s());
     reals = s.reals();
 
-    if (_search_info.search_bounds.has_value()){
-
+    if (!_search_info.allow_goal_overshoot){
       geometry_msgs::Pose node_in_world_frame = Utils::getWorldCoords(reals[0], reals[1], _collision_checker->getCostmap());
-      bool is_node_behind_goal = Utils::checkIfPointBelowPose(node_in_world_frame.position.x, node_in_world_frame.position.y, _search_info.search_bounds.value());
-      if (is_node_behind_goal != is_start_behind_goal){ // not equal means not on the same side
+      bool is_node_behind_goal = Utils::checkIfPointBelowPose(node_in_world_frame.position.x, node_in_world_frame.position.y, _search_info.search_bounds);
+      if (is_node_behind_goal != _is_start_behind_goal){ // not equal means not on the same side
           failure = true;
           break;
       }

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -209,10 +209,40 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
   std::vector<float> node_costs;
   node_costs.reserve(num_intervals);
 
+  // Get goal pose in world coordinates
+  float goal_x = _collision_checker->getCostmap()->getOriginX() +
+                ((goal->pose.x + 0.5f) * _collision_checker->getCostmap()->getResolution());
+  float goal_y = _collision_checker->getCostmap()->getOriginY() +
+                ((goal->pose.y + 0.5f) * _collision_checker->getCostmap()->getResolution());
+
   // Check intermediary poses (non-goal, non-start)
   for (float i = 1; i < num_intervals; i++) {
     state_space->interpolate(from(), to(), i / num_intervals, s());
     reals = s.reals();
+
+    // Check if this point is above the goal pose
+    float current_x = _collision_checker->getCostmap()->getOriginX() +
+                     ((reals[0] + 0.5f) * _collision_checker->getCostmap()->getResolution());
+    float current_y = _collision_checker->getCostmap()->getOriginY() +
+                     ((reals[1] + 0.5f) * _collision_checker->getCostmap()->getResolution());
+
+    // Vector from goal to current point
+    float dx = current_x - goal_x;
+    float dy = current_y - goal_y;
+
+    // Get goal orientation
+    float goal_theta = node->motion_table.getAngleFromBin(goal->pose.theta);
+    float goal_dx = cos(goal_theta);
+    float goal_dy = sin(goal_theta);
+
+    // Dot product to check if point is in front of goal
+    float dot = dx * goal_dx + dy * goal_dy;
+
+    // If dot > 0, point is in front of goal (above the goal pose)
+    if (dot > 0) {
+      failure = true;
+      break;
+    }
     // Make sure in range [0, 2PI)
     theta = (reals[2] < 0.0) ? (reals[2] + 2.0 * M_PI) : reals[2];
     theta = (theta > 2.0 * M_PI) ? (theta - 2.0 * M_PI) : theta;

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -218,6 +218,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
   std::vector<float> node_costs;
   node_costs.reserve(num_intervals);
 
+  // Check intermediary poses (non-goal, non-start)
   for (float i = 1; i < num_intervals; i++) {
     state_space->interpolate(from(), to(), i / num_intervals, s());
     reals = s.reals();

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -225,7 +225,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
 
     if (!_search_info.allow_goal_overshoot){
       geometry_msgs::Pose node_in_world_frame = Utils::getWorldCoords(reals[0], reals[1], _collision_checker->getCostmap());
-      bool is_node_behind_goal = Utils::isBehindPose(node_in_world_frame.position, _search_info.search_bounds.pose);
+      const bool is_node_behind_goal = Utils::isBehindPose(node_in_world_frame.position, _search_info.search_bounds.pose);
       if (is_node_behind_goal != _search_info.is_start_behind_goal){ // not equal means not on the same side
           failure = true;
           break;

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -15,11 +15,12 @@
 #include <ompl/base/ScopedState.h>
 #include <ompl/base/spaces/DubinsStateSpace.h>
 #include <ompl/base/spaces/ReedsSheppStateSpace.h>
-
 #include <algorithm>
 #include <vector>
 #include <memory>
-
+#include "geometry_msgs/Point.h"
+#include "geometry_msgs/PoseStamped.h"
+#include <smac_planner/utils.hpp>
 #include "smac_planner/analytic_expansion.hpp"
 
 namespace smac_planner
@@ -48,11 +49,11 @@ void AnalyticExpansion<NodeT>::setCollisionChecker(
 
 template<typename NodeT>
 void AnalyticExpansion<NodeT>::setSearchBounds(
-  const geometry_msgs::PoseStamped &search_bounds, bool allow_goal_overshoot, bool is_start_behind_goal)
+  const geometry_msgs::Pose &search_bounds, const geometry_msgs::Point& start_point, bool allow_goal_overshoot)
 {
-  _search_info.search_bounds = search_bounds;
+  _search_info.setSearchBound(search_bounds);
+  _search_info.setStart(start_point);
   _search_info.allow_goal_overshoot = allow_goal_overshoot;
-  _search_info.is_start_behind_goal = is_start_behind_goal;
 }
 
 template<typename NodeT>
@@ -217,6 +218,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
   bool failure = false;
   std::vector<float> node_costs;
   node_costs.reserve(num_intervals);
+  const bool is_start_behind_goal = _search_info.isStartBehindSearchBounds();
 
   // Check intermediary poses (non-goal, non-start)
   for (float i = 1; i < num_intervals; i++) {
@@ -225,8 +227,8 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
 
     if (!_search_info.allow_goal_overshoot){
       geometry_msgs::Pose node_in_world_frame = Utils::getWorldCoords(reals[0], reals[1], _collision_checker->getCostmap());
-      const bool is_node_behind_goal = Utils::isBehindPose(node_in_world_frame.position, _search_info.search_bounds.pose);
-      if (is_node_behind_goal != _search_info.is_start_behind_goal){ // not equal means not on the same side
+      const bool is_node_behind_goal = Utils::isBehindPose(node_in_world_frame.position, _search_info.getSearchBound());
+      if (is_node_behind_goal != is_start_behind_goal){ // not equal means not on the same side
           failure = true;
           break;
       }

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -48,16 +48,16 @@ void AnalyticExpansion<NodeT>::setCollisionChecker(
 
 template<typename NodeT>
 void AnalyticExpansion<NodeT>::setSearchBounds(
-  const geometry_msgs::PoseStamped &search_bounds, bool behind)
+  const geometry_msgs::PoseStamped &search_bounds, const geometry_msgs::PoseStamped& start)
 {
-  _search_info.search_bounds.first = search_bounds;
-  _search_info.search_bounds.second = behind;
+  _search_info.search_bounds = search_bounds;
+  _search_info.start_pose = start;
 }
 
 template<typename NodeT>
 void AnalyticExpansion<NodeT>::clearSearchBounds()
 {
-  _search_info.search_bounds.first.reset();
+  _search_info.search_bounds.reset();
 }
 
 
@@ -224,37 +224,22 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
   std::vector<float> node_costs;
   node_costs.reserve(num_intervals);
 
+  bool is_start_behind_goal;
+  if (_search_info.search_bounds.has_value()){
+    is_start_behind_goal = Utils::checkIfPointBelowPose(_search_info.start_pose.pose.position.x, _search_info.start_pose.pose.position.y, _search_info.search_bounds.value());
+  }
+
   for (float i = 1; i < num_intervals; i++) {
     state_space->interpolate(from(), to(), i / num_intervals, s());
     reals = s.reals();
 
-    // Check if this point is above the goal pose
-    if (_search_info.search_bounds.first.has_value()){
-      float current_x = _collision_checker->getCostmap()->getOriginX() +
-                      ((reals[0] + 0.5f) * _collision_checker->getCostmap()->getResolution());
-      float current_y = _collision_checker->getCostmap()->getOriginY() +
-                      ((reals[1] + 0.5f) * _collision_checker->getCostmap()->getResolution());
+    if (_search_info.search_bounds.has_value()){
 
-      // Vector from goal to current point
-      float dx = current_x - _search_info.search_bounds.first.value().pose.position.x;
-      float dy = current_y - _search_info.search_bounds.first.value().pose.position.y;
-
-      // Get goal orientation
-      float goal_theta = node->motion_table.getAngleFromBin(goal->pose.theta);
-      float goal_dx = cos(goal_theta);
-      float goal_dy = sin(goal_theta);
-
-      // Dot product to check if point is in front of goal
-      float dot = dx * goal_dx + dy * goal_dy;
-
-      // If dot > 0, point is in front of goal (above the goal pose)
-      if (dot > 0 && _search_info.search_bounds.second) {
-        failure = true;
-        break;
-      }
-      if (dot < 0 && !_search_info.search_bounds.second) {
-        failure = true;
-        break;
+      geometry_msgs::Pose node_in_world_frame = Utils::getWorldCoords(reals[0], reals[1], _collision_checker->getCostmap());
+      bool is_node_behind_goal = Utils::checkIfPointBelowPose(node_in_world_frame.position.x, node_in_world_frame.position.y, _search_info.search_bounds.value());
+      if (is_node_behind_goal != is_start_behind_goal){ // not equal means not on the same side
+          failure = true;
+          break;
       }
     }
 

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -18,8 +18,7 @@
 #include <algorithm>
 #include <vector>
 #include <memory>
-#include "geometry_msgs/Point.h"
-#include "geometry_msgs/PoseStamped.h"
+#include <geometry_msgs/Point.h>
 #include <smac_planner/utils.hpp>
 #include "smac_planner/analytic_expansion.hpp"
 

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -47,6 +47,20 @@ void AnalyticExpansion<NodeT>::setCollisionChecker(
 }
 
 template<typename NodeT>
+void AnalyticExpansion<NodeT>::setSearchBounds(
+  const geometry_msgs::PoseStamped &search_bounds)
+{
+  _search_info.search_bounds = search_bounds;
+}
+
+template<typename NodeT>
+void AnalyticExpansion<NodeT>::clearSearchBounds()
+{
+  _search_info.search_bounds.reset();
+}
+
+
+template<typename NodeT>
 typename AnalyticExpansion<NodeT>::NodePtr AnalyticExpansion<NodeT>::tryAnalyticExpansion(
   const NodePtr & current_node, const NodePtr & goal_node,
   const NodeGetter & getter, int & analytic_iterations,
@@ -209,39 +223,38 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
   std::vector<float> node_costs;
   node_costs.reserve(num_intervals);
 
-  // Get goal pose in world coordinates
-  float goal_x = _collision_checker->getCostmap()->getOriginX() +
-                ((goal->pose.x + 0.5f) * _collision_checker->getCostmap()->getResolution());
-  float goal_y = _collision_checker->getCostmap()->getOriginY() +
-                ((goal->pose.y + 0.5f) * _collision_checker->getCostmap()->getResolution());
-
-  // Check intermediary poses (non-goal, non-start)
   for (float i = 1; i < num_intervals; i++) {
     state_space->interpolate(from(), to(), i / num_intervals, s());
     reals = s.reals();
 
     // Check if this point is above the goal pose
-    float current_x = _collision_checker->getCostmap()->getOriginX() +
-                     ((reals[0] + 0.5f) * _collision_checker->getCostmap()->getResolution());
-    float current_y = _collision_checker->getCostmap()->getOriginY() +
-                     ((reals[1] + 0.5f) * _collision_checker->getCostmap()->getResolution());
+    if (_search_info.search_bounds.has_value()){
+      float current_x = _collision_checker->getCostmap()->getOriginX() +
+                      ((reals[0] + 0.5f) * _collision_checker->getCostmap()->getResolution());
+      float current_y = _collision_checker->getCostmap()->getOriginY() +
+                      ((reals[1] + 0.5f) * _collision_checker->getCostmap()->getResolution());
 
-    // Vector from goal to current point
-    float dx = current_x - goal_x;
-    float dy = current_y - goal_y;
+      // Vector from goal to current point
+      float dx = current_x - _search_info.search_bounds.value().pose.position.x;
+      float dy = current_y - _search_info.search_bounds.value().pose.position.y;
 
-    // Get goal orientation
-    float goal_theta = node->motion_table.getAngleFromBin(goal->pose.theta);
-    float goal_dx = cos(goal_theta);
-    float goal_dy = sin(goal_theta);
+      // Get goal orientation
+      float goal_theta = node->motion_table.getAngleFromBin(goal->pose.theta);
+      float goal_dx = cos(goal_theta);
+      float goal_dy = sin(goal_theta);
 
-    // Dot product to check if point is in front of goal
-    float dot = dx * goal_dx + dy * goal_dy;
+      // Dot product to check if point is in front of goal
+      float dot = dx * goal_dx + dy * goal_dy;
 
-    // If dot > 0, point is in front of goal (above the goal pose)
-    if (dot > 0) {
-      failure = true;
-      break;
+      // If dot > 0, point is in front of goal (above the goal pose)
+      if (dot > 0) {
+        failure = true;
+        break;
+      }
+    }
+
+    else{
+      ROS_ERROR("FAIL");
     }
     // Make sure in range [0, 2PI)
     theta = (reals[2] < 0.0) ? (reals[2] + 2.0 * M_PI) : reals[2];

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -52,7 +52,7 @@ void AnalyticExpansion<NodeT>::setSearchBounds(
 {
   _search_info.search_bounds = search_bounds;
   _search_info.allow_goal_overshoot = allow_goal_overshoot;
-  _is_start_behind_goal = is_start_behind_goal;
+  _search_info.is_start_behind_goal = is_start_behind_goal;
 }
 
 template<typename NodeT>
@@ -226,7 +226,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
     if (!_search_info.allow_goal_overshoot){
       geometry_msgs::Pose node_in_world_frame = Utils::getWorldCoords(reals[0], reals[1], _collision_checker->getCostmap());
       bool is_node_behind_goal = Utils::isBehindPose(node_in_world_frame.position, _search_info.search_bounds.pose);
-      if (is_node_behind_goal != _is_start_behind_goal){ // not equal means not on the same side
+      if (is_node_behind_goal != _search_info.is_start_behind_goal){ // not equal means not on the same side
           failure = true;
           break;
       }

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -224,7 +224,7 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
 
     if (!_search_info.allow_goal_overshoot){
       geometry_msgs::Pose node_in_world_frame = Utils::getWorldCoords(reals[0], reals[1], _collision_checker->getCostmap());
-      bool is_node_behind_goal = Utils::checkIfPointBelowPose(node_in_world_frame.position.x, node_in_world_frame.position.y, _search_info.search_bounds);
+      bool is_node_behind_goal = Utils::isBehindPose(node_in_world_frame, _search_info.search_bounds);
       if (is_node_behind_goal != _is_start_behind_goal){ // not equal means not on the same side
           failure = true;
           break;

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -48,15 +48,16 @@ void AnalyticExpansion<NodeT>::setCollisionChecker(
 
 template<typename NodeT>
 void AnalyticExpansion<NodeT>::setSearchBounds(
-  const geometry_msgs::PoseStamped &search_bounds)
+  const geometry_msgs::PoseStamped &search_bounds, bool behind)
 {
-  _search_info.search_bounds = search_bounds;
+  _search_info.search_bounds.first = search_bounds;
+  _search_info.search_bounds.second = behind;
 }
 
 template<typename NodeT>
 void AnalyticExpansion<NodeT>::clearSearchBounds()
 {
-  _search_info.search_bounds.reset();
+  _search_info.search_bounds.first.reset();
 }
 
 
@@ -228,15 +229,15 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
     reals = s.reals();
 
     // Check if this point is above the goal pose
-    if (_search_info.search_bounds.has_value()){
+    if (_search_info.search_bounds.first.has_value()){
       float current_x = _collision_checker->getCostmap()->getOriginX() +
                       ((reals[0] + 0.5f) * _collision_checker->getCostmap()->getResolution());
       float current_y = _collision_checker->getCostmap()->getOriginY() +
                       ((reals[1] + 0.5f) * _collision_checker->getCostmap()->getResolution());
 
       // Vector from goal to current point
-      float dx = current_x - _search_info.search_bounds.value().pose.position.x;
-      float dy = current_y - _search_info.search_bounds.value().pose.position.y;
+      float dx = current_x - _search_info.search_bounds.first.value().pose.position.x;
+      float dy = current_y - _search_info.search_bounds.first.value().pose.position.y;
 
       // Get goal orientation
       float goal_theta = node->motion_table.getAngleFromBin(goal->pose.theta);
@@ -247,7 +248,11 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
       float dot = dx * goal_dx + dy * goal_dy;
 
       // If dot > 0, point is in front of goal (above the goal pose)
-      if (dot > 0) {
+      if (dot > 0 && _search_info.search_bounds.second) {
+        failure = true;
+        break;
+      }
+      if (dot < 0 && !_search_info.search_bounds.second) {
         failure = true;
         break;
       }

--- a/src/analytic_expansion.cpp
+++ b/src/analytic_expansion.cpp
@@ -253,9 +253,6 @@ typename AnalyticExpansion<NodeT>::AnalyticExpansionNodes AnalyticExpansion<Node
       }
     }
 
-    else{
-      ROS_ERROR("FAIL");
-    }
     // Make sure in range [0, 2PI)
     theta = (reals[2] < 0.0) ? (reals[2] + 2.0 * M_PI) : reals[2];
     theta = (theta > 2.0 * M_PI) ? (theta - 2.0 * M_PI) : theta;

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -386,7 +386,6 @@ float NodeHybrid::getTraversalCost(const NodePtr & child)
             "Node attempted to get traversal "
             "cost without a known SE2 collision cost!");
   }
-  ROS_ERROR("NodeHybrid::getTraversalCost");
   // this is the first node
   if (getMotionPrimitiveIndex() == std::numeric_limits<unsigned int>::max()) {
     return NodeHybrid::travel_distance_cost;

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -17,15 +17,12 @@
 #include <vector>
 #include <memory>
 #include <algorithm>
-#include <queue>
 #include <limits>
 #include <utility>
 
 #include "ompl/base/ScopedState.h"
 #include "ompl/base/spaces/DubinsStateSpace.h"
 #include "ompl/base/spaces/ReedsSheppStateSpace.h"
-
-#include "smac_planner/utils.hpp"
 
 #include "smac_planner/node_hybrid.hpp"
 
@@ -386,6 +383,7 @@ float NodeHybrid::getTraversalCost(const NodePtr & child)
             "Node attempted to get traversal "
             "cost without a known SE2 collision cost!");
   }
+
   // this is the first node
   if (getMotionPrimitiveIndex() == std::numeric_limits<unsigned int>::max()) {
     return NodeHybrid::travel_distance_cost;

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -386,7 +386,7 @@ float NodeHybrid::getTraversalCost(const NodePtr & child)
             "Node attempted to get traversal "
             "cost without a known SE2 collision cost!");
   }
-
+  ROS_ERROR("NodeHybrid::getTraversalCost");
   // this is the first node
   if (getMotionPrimitiveIndex() == std::numeric_limits<unsigned int>::max()) {
     return NodeHybrid::travel_distance_cost;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -94,7 +94,7 @@ void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t 
   _search_info.allow_primitive_interpolation = _config.allow_primitive_interpolation;
   _search_info.downsample_obstacle_heuristic = _config.downsample_obstacle_heuristic;
   _search_info.use_quadratic_cost_penalty = _config.use_quadratic_cost_penalty;
-  _allow_goal_overshoot = config.allow_goal_overshoot;
+  _allow_goal_overshoot = _config.allow_goal_overshoot;
 
 
   if (_config.max_on_approach_iterations <= 0) {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -165,34 +165,6 @@ void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t 
     _config.tolerance, toString(_motion_model).c_str());
 }
 
-bool SmacPlannerHybrid::checkIfPoseBelowPose(const geometry_msgs::PoseStamped& start_pose, const geometry_msgs::PoseStamped& goal_pose){
-  float start_x = start_pose.pose.position.x;
-  float start_y = start_pose.pose.position.y;
-  float goal_x = goal_pose.pose.position.x;
-  float goal_y = goal_pose.pose.position.y;
-
-  tf2::Quaternion q(
-    goal_pose.pose.orientation.x,
-    goal_pose.pose.orientation.y,
-    goal_pose.pose.orientation.z,
-    goal_pose.pose.orientation.w);
-  double roll, pitch, yaw;
-  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
-
-  float dx = std::cos(yaw);
-  float dy = std::sin(yaw);
-
-  // Vector from pose to node
-  float vx = start_x - goal_x;
-  float vy = start_y - goal_y;
-
-  // Dot product to check if node is behind the perpendicular
-  float dot = vx * dx + vy * dy;
-
-  // If dot < 0, node is behind pose’s perpendicular line
-  return (dot < 0);
-}
-
 uint32_t SmacPlannerHybrid::makePlan(
     const geometry_msgs::PoseStamped & start,
     const geometry_msgs::PoseStamped & goal,
@@ -202,7 +174,6 @@ uint32_t SmacPlannerHybrid::makePlan(
     std::string &message)
 {
   _planning_canceled = false;
-
   std::lock_guard<std::mutex> lock_reinit(_mutex);
   ros::Time a = ros::Time::now();
 
@@ -222,11 +193,7 @@ uint32_t SmacPlannerHybrid::makePlan(
   _a_star->setCollisionChecker(_collision_checker.get());
 
   if (_disable_goal_overshoot) {
-    if (checkIfPoseBelowPose(start, goal)) {
-      _a_star->setSearchBounds(goal, true); // A* will not expand search ahead of goal pose
-    } else {
-      _a_star->setSearchBounds(goal, false); // A* will not expand search behind of goal pose
-    }
+      _a_star->setSearchBounds(goal, start);
   } else {
     _a_star->clearSearchBounds();
   }

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -95,6 +95,8 @@ void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t 
   _search_info.allow_primitive_interpolation = _config.allow_primitive_interpolation;
   _search_info.downsample_obstacle_heuristic = _config.downsample_obstacle_heuristic;
   _search_info.use_quadratic_cost_penalty = _config.use_quadratic_cost_penalty;
+  _disable_goal_overshoot = config.disable_goal_overshoot;
+
 
   if (_config.max_on_approach_iterations <= 0) {
     ROS_WARN("On approach iteration selected as <= 0, "
@@ -190,7 +192,13 @@ uint32_t SmacPlannerHybrid::makePlan(
       _costmap_ros->getUseRadius(),
       Utils::findCircumscribedCost(_costmap_ros.get()));
   _a_star->setCollisionChecker(_collision_checker.get());
-  _a_star->setSearchBounds(goal); // astar will not expand search to cells ahead of goal pose, planning will fail if robot pose and goal pose are facing opposite side
+
+  if(_disable_goal_overshoot){
+    _a_star->setSearchBounds(goal); // astar will not expand search to cells ahead of goal pose, planning will fail if robot pose and goal pose are facing opposite side
+  }
+  else{
+   _a_star->clearSearchBounds();
+  }
 
   // Set starting point, in A* bin search coordinates
   float mx, my;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -223,18 +223,10 @@ uint32_t SmacPlannerHybrid::makePlan(
 
   if (_disable_goal_overshoot) {
     if (checkIfPoseBelowPose(start, goal)) {
-      _a_star->setSearchBounds(goal); // A* will not expand search ahead of goal pose
+      _a_star->setSearchBounds(goal, true); // A* will not expand search ahead of goal pose
     } else {
       ROS_ERROR("\n\nELSE SPECIAL CASE\n\n");
-      geometry_msgs::PoseStamped adjusted_goal = goal;
-      tf2::Quaternion q_orig, q_rot, q_new;
-      tf2::fromMsg(goal.pose.orientation, q_orig);
-      // 180 degrees rotation about Z axis
-      q_rot.setRPY(0, 0, M_PI);
-      q_new = q_rot * q_orig;
-      q_new.normalize();
-      adjusted_goal.pose.orientation = tf2::toMsg(q_new);
-      _a_star->setSearchBounds(adjusted_goal);
+      _a_star->setSearchBounds(goal, false); // A* will not expand search behind of goal pose
     }
   } else {
     _a_star->clearSearchBounds();

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -190,6 +190,7 @@ uint32_t SmacPlannerHybrid::makePlan(
       _costmap_ros->getUseRadius(),
       Utils::findCircumscribedCost(_costmap_ros.get()));
   _a_star->setCollisionChecker(_collision_checker.get());
+  _a_star->setSearchBounds(goal); // astar will not expand search to cells ahead of goal pose, planning will fail if robot pose and goal pose are facing opposite side
 
   // Set starting point, in A* bin search coordinates
   float mx, my;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -21,6 +21,7 @@
 #include "Eigen/Core"
 
 #include "mbf_msgs/GetPathResult.h"
+#include "smac_planner/utils.hpp"
 
 #include "smac_planner/smac_planner_hybrid.hpp"
 
@@ -95,7 +96,7 @@ void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t 
   _search_info.allow_primitive_interpolation = _config.allow_primitive_interpolation;
   _search_info.downsample_obstacle_heuristic = _config.downsample_obstacle_heuristic;
   _search_info.use_quadratic_cost_penalty = _config.use_quadratic_cost_penalty;
-  _disable_goal_overshoot = config.disable_goal_overshoot;
+  _allow_goal_overshoot = config.allow_goal_overshoot;
 
 
   if (_config.max_on_approach_iterations <= 0) {
@@ -191,12 +192,10 @@ uint32_t SmacPlannerHybrid::makePlan(
       _costmap_ros->getUseRadius(),
       Utils::findCircumscribedCost(_costmap_ros.get()));
   _a_star->setCollisionChecker(_collision_checker.get());
+  bool is_start_behind_goal = Utils::checkIfPointBelowPose(start.pose.position.x, start.pose.position.y, goal);
+  _a_star->setSearchBounds(goal, _allow_goal_overshoot, is_start_behind_goal);
 
-  if (_disable_goal_overshoot) {
-      _a_star->setSearchBounds(goal, start);
-  } else {
-    _a_star->clearSearchBounds();
-  }
+
 
   // Set starting point, in A* bin search coordinates
   float mx, my;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -165,6 +165,34 @@ void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t 
     _config.tolerance, toString(_motion_model).c_str());
 }
 
+bool SmacPlannerHybrid::checkIfPoseBelowPose(const geometry_msgs::PoseStamped& start_pose, const geometry_msgs::PoseStamped& goal_pose){
+  float start_x = start_pose.pose.position.x;
+  float start_y = start_pose.pose.position.y;
+  float goal_x = goal_pose.pose.position.x;
+  float goal_y = goal_pose.pose.position.y;
+
+  tf2::Quaternion q(
+    goal_pose.pose.orientation.x,
+    goal_pose.pose.orientation.y,
+    goal_pose.pose.orientation.z,
+    goal_pose.pose.orientation.w);
+  double roll, pitch, yaw;
+  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+
+  float dx = std::cos(yaw);
+  float dy = std::sin(yaw);
+
+  // Vector from pose to node
+  float vx = start_x - goal_x;
+  float vy = start_y - goal_y;
+
+  // Dot product to check if node is behind the perpendicular
+  float dot = vx * dx + vy * dy;
+
+  // If dot < 0, node is behind pose’s perpendicular line
+  return (dot < 0);
+}
+
 uint32_t SmacPlannerHybrid::makePlan(
     const geometry_msgs::PoseStamped & start,
     const geometry_msgs::PoseStamped & goal,
@@ -193,11 +221,23 @@ uint32_t SmacPlannerHybrid::makePlan(
       Utils::findCircumscribedCost(_costmap_ros.get()));
   _a_star->setCollisionChecker(_collision_checker.get());
 
-  if(_disable_goal_overshoot){
-    _a_star->setSearchBounds(goal); // astar will not expand search to cells ahead of goal pose, planning will fail if robot pose and goal pose are facing opposite side
-  }
-  else{
-   _a_star->clearSearchBounds();
+  if (_disable_goal_overshoot) {
+    if (checkIfPoseBelowPose(start, goal)) {
+      _a_star->setSearchBounds(goal); // A* will not expand search ahead of goal pose
+    } else {
+      ROS_ERROR("\n\nELSE SPECIAL CASE\n\n");
+      geometry_msgs::PoseStamped adjusted_goal = goal;
+      tf2::Quaternion q_orig, q_rot, q_new;
+      tf2::fromMsg(goal.pose.orientation, q_orig);
+      // 180 degrees rotation about Z axis
+      q_rot.setRPY(0, 0, M_PI);
+      q_new = q_rot * q_orig;
+      q_new.normalize();
+      adjusted_goal.pose.orientation = tf2::toMsg(q_new);
+      _a_star->setSearchBounds(adjusted_goal);
+    }
+  } else {
+    _a_star->clearSearchBounds();
   }
 
   // Set starting point, in A* bin search coordinates

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -18,8 +18,6 @@
 #include <vector>
 #include <limits>
 
-#include "Eigen/Core"
-
 #include "mbf_msgs/GetPathResult.h"
 #include "smac_planner/utils.hpp"
 
@@ -175,6 +173,7 @@ uint32_t SmacPlannerHybrid::makePlan(
     std::string &message)
 {
   _planning_canceled = false;
+
   std::lock_guard<std::mutex> lock_reinit(_mutex);
   ros::Time a = ros::Time::now();
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -191,7 +191,7 @@ uint32_t SmacPlannerHybrid::makePlan(
       _costmap_ros->getUseRadius(),
       Utils::findCircumscribedCost(_costmap_ros.get()));
   _a_star->setCollisionChecker(_collision_checker.get());
-  bool is_start_behind_goal = Utils::isBehindPose(start.pose, goal);
+  bool is_start_behind_goal = Utils::isBehindPose(start.pose.position, goal.pose);
   _a_star->setSearchBounds(goal, _allow_goal_overshoot, is_start_behind_goal);
 
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -94,7 +94,7 @@ void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t 
   _search_info.allow_primitive_interpolation = _config.allow_primitive_interpolation;
   _search_info.downsample_obstacle_heuristic = _config.downsample_obstacle_heuristic;
   _search_info.use_quadratic_cost_penalty = _config.use_quadratic_cost_penalty;
-  _allow_goal_overshoot = _config.allow_goal_overshoot;
+  _search_info.allow_goal_overshoot = _config.allow_goal_overshoot;
 
 
   if (_config.max_on_approach_iterations <= 0) {
@@ -191,8 +191,7 @@ uint32_t SmacPlannerHybrid::makePlan(
       _costmap_ros->getUseRadius(),
       Utils::findCircumscribedCost(_costmap_ros.get()));
   _a_star->setCollisionChecker(_collision_checker.get());
-  bool is_start_behind_goal = Utils::isBehindPose(start.pose.position, goal.pose);
-  _a_star->setSearchBounds(goal, _allow_goal_overshoot, is_start_behind_goal);
+  _a_star->setSearchBounds(goal, _search_info.allow_goal_overshoot, Utils::isBehindPose(start.pose.position, goal.pose));
 
 
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -192,7 +192,7 @@ uint32_t SmacPlannerHybrid::makePlan(
       _costmap_ros->getUseRadius(),
       Utils::findCircumscribedCost(_costmap_ros.get()));
   _a_star->setCollisionChecker(_collision_checker.get());
-  bool is_start_behind_goal = Utils::checkIfPointBelowPose(start.pose.position.x, start.pose.position.y, goal);
+  bool is_start_behind_goal = Utils::isBehindPose(start.pose, goal);
   _a_star->setSearchBounds(goal, _allow_goal_overshoot, is_start_behind_goal);
 
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -225,7 +225,6 @@ uint32_t SmacPlannerHybrid::makePlan(
     if (checkIfPoseBelowPose(start, goal)) {
       _a_star->setSearchBounds(goal, true); // A* will not expand search ahead of goal pose
     } else {
-      ROS_ERROR("\n\nELSE SPECIAL CASE\n\n");
       _a_star->setSearchBounds(goal, false); // A* will not expand search behind of goal pose
     }
   } else {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -191,9 +191,7 @@ uint32_t SmacPlannerHybrid::makePlan(
       _costmap_ros->getUseRadius(),
       Utils::findCircumscribedCost(_costmap_ros.get()));
   _a_star->setCollisionChecker(_collision_checker.get());
-  _a_star->setSearchBounds(goal, _search_info.allow_goal_overshoot, Utils::isBehindPose(start.pose.position, goal.pose));
-
-
+  _a_star->setSearchBounds(goal.pose, start.pose.position, _search_info.allow_goal_overshoot);
 
   // Set starting point, in A* bin search coordinates
   float mx, my;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,0 +1,35 @@
+#include <smac_planner/types.hpp>
+#include <geometry_msgs/Point.h>
+#include <smac_planner/utils.hpp>
+
+namespace smac_planner
+{
+
+void SearchInfo::setStart(const geometry_msgs::Point& start){
+  _start_pose = start;
+  is_start_behind_goal.reset();
+}
+
+geometry_msgs::Pose SearchInfo::getSearchBound(){
+  return _search_bound;
+}
+
+void SearchInfo::setSearchBound(const geometry_msgs::Pose& search_bound){
+  _search_bound = search_bound;
+  is_start_behind_goal.reset();
+}
+
+bool SearchInfo::isStartBehindSearchBounds(){
+  assert(_start_pose.header.stamp != ros::Time(0) && "Start pose not set");
+  assert(_search_bound.header.stamp != ros::Time(0) && "Search bound pose not set");
+
+  if (is_start_behind_goal){
+    return *is_start_behind_goal;
+  }
+  else{
+    is_start_behind_goal = smac_planner::Utils::isBehindPose(_start_pose, _search_bound);
+    return *is_start_behind_goal;
+  }
+}
+
+}  // namespace smac_planner

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -20,8 +20,6 @@ void SearchInfo::setSearchBound(const geometry_msgs::Pose& search_bound){
 }
 
 bool SearchInfo::isStartBehindSearchBounds(){
-  assert(_start_pose.header.stamp != ros::Time(0) && "Start pose not set");
-  assert(_search_bound.header.stamp != ros::Time(0) && "Search bound pose not set");
 
   if (is_start_behind_goal){
     return *is_start_behind_goal;


### PR DESCRIPTION
Task Link: [AB#68648](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/68648)
When allow_goal_overshoot = False, we don't allow Hybrid A* to search beyond the cells that are ahead of the goal pose, to make it generate a path that always connects from behind and never overshoots the goal. For docking like scenarios.

![image](https://github.com/user-attachments/assets/ce84b58b-cd69-4c46-8308-8a7a61cca5d9)
![image](https://github.com/user-attachments/assets/55034087-121a-4b16-b38b-896864317836)


Path when allow_goal_overshoot = True:
![image](https://github.com/user-attachments/assets/63574f12-5e9f-4760-80e8-6193b9d6e963)


Path when allow_goal_overshoot = False:
![image](https://github.com/user-attachments/assets/967a1c31-fc06-43db-bf13-1d603c262843)
