### PR TITLE
fix: start and goal same when goal_align_dist>0

### DIFF
--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -16,7 +16,6 @@
 #ifndef SMAC_PLANNER__UTILS_HPP_
 #define SMAC_PLANNER__UTILS_HPP_
 
-#include <cmath>
 #include <vector>
 #include <memory>
 #include <string>
@@ -89,14 +88,11 @@ public:
   * @return Bool true they are under tolerance, false means they are not in tolerance
   */
   static inline bool isSamePose(geometry_msgs::Pose pose1, geometry_msgs::Pose pose2, double tolerance){
-    double yaw_offset = angles::shortest_angular_distance(tf2::getYaw(pose1.orientation), tf2::getYaw(pose2.orientation));
-    double distance = std::hypot(pose1.position.x - pose2.position.x,
+    const double yaw_offset = angles::shortest_angular_distance(tf2::getYaw(pose1.orientation), tf2::getYaw(pose2.orientation));
+    const double distance = std::hypot(pose1.position.x - pose2.position.x,
       pose1.position.y - pose2.position.y);
-
-    if (distance <= tolerance && yaw_offset <= tolerance){
-      return  true;
-    }
-    return false;
+    
+    return distance <= tolerance && yaw_offset <= tolerance;
   }
 
 

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -16,6 +16,7 @@
 #ifndef SMAC_PLANNER__UTILS_HPP_
 #define SMAC_PLANNER__UTILS_HPP_
 
+#include <cmath>
 #include <vector>
 #include <memory>
 #include <string>
@@ -80,6 +81,23 @@ public:
       float dot = vx * dx + vy * dy;
       return (dot < 0);
     }
+
+
+  /**
+  * @brief Check if the input poses are within specified tolerance
+  * @return Bool true they are under tolerance, false means they are not in tolerance
+  */
+  static inline bool arePoseWithinTolerance(geometry_msgs::Pose pose1, geometry_msgs::Pose pose2, double tolerance){
+
+    double yaw_offset = std::abs(tf2::getYaw(pose1.orientation) -  tf2::getYaw(pose2.orientation));
+    double distance = std::hypot(pose1.position.x - pose2.position.x,
+      pose1.position.y - pose2.position.y);
+
+    if (distance <= tolerance && yaw_offset <= tolerance){
+      return  true;
+    }
+    return false;
+  }
 
 
   /**

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <geometry_msgs/Point.h>
+#include "angles/angles.h"
 #include "nlohmann/json.hpp"
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Pose.h"
@@ -87,9 +88,8 @@ public:
   * @brief Check if the input poses are within specified tolerance
   * @return Bool true they are under tolerance, false means they are not in tolerance
   */
-  static inline bool arePoseWithinTolerance(geometry_msgs::Pose pose1, geometry_msgs::Pose pose2, double tolerance){
-
-    double yaw_offset = std::abs(tf2::getYaw(pose1.orientation) -  tf2::getYaw(pose2.orientation));
+  static inline bool isSamePose(geometry_msgs::Pose pose1, geometry_msgs::Pose pose2, double tolerance){
+    double yaw_offset = angles::shortest_angular_distance(tf2::getYaw(pose1.orientation), tf2::getYaw(pose2.orientation));
     double distance = std::hypot(pose1.position.x - pose2.position.x,
       pose1.position.y - pose2.position.y);
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -219,6 +219,13 @@ uint32_t SmacPlannerHybrid::makePlan(
 
   PlanResult plan_result;
 
+  // check if the start is already under tolerance within the goal
+  if (Utils::arePoseWithinTolerance(start.pose, goal.pose, tolerance)){
+    ROS_INFO_NAMED("", "start and goal same or goal under tolerance");
+    plan = {};
+    return mbf_msgs::GetPathResult::SUCCESS;
+  }
+
   if (!_search_info.allow_goal_overshoot) {
     _search_info.setSearchBound(goal.pose);
     _search_info.setStart(start.pose.position);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -220,8 +220,8 @@ uint32_t SmacPlannerHybrid::makePlan(
   PlanResult plan_result;
 
   // check if the start is already under tolerance within the goal
-  if (Utils::arePoseWithinTolerance(start.pose, goal.pose, tolerance)){
-    ROS_INFO_NAMED("", "start and goal same or goal under tolerance");
+  if (Utils::isSamePose(start.pose, goal.pose, tolerance)){
+    ROS_INFO_NAMED("smac_planner_hybrid", "Start and goal same or goal under tolerance");
     plan = {};
     return mbf_msgs::GetPathResult::SUCCESS;
   }


### PR DESCRIPTION
When goal_align_dist > 0 and we give the goal such that it is already under tolerance, then the robot will move to the waypoint and then come back to the goal. While it should stay where it is.