### PR TITLE
fix: no visualisation published when goal_align_dist = 0

### DIFF
--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -155,6 +155,14 @@ protected:
   ros::Publisher _waypoint_publisher;
   ros::Publisher _collision_pub;
   std::mutex _mutex;
+
+  /**
+   *@brief publishes the visualisations like path, waypoint, footprints. To be called at end of the planning
+   *@param plan vector of geometry_msgs::PoseStamped
+   *@param waypoint pointer to the waypoint of type geometry_msgs::PoseStamped
+  */
+  void publish_visualisations(const std::vector<geometry_msgs::PoseStamped>& plan, const geometry_msgs::PoseStamped* waypoint);
+
 };
 
 }  // namespace smac_planner

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -161,7 +161,7 @@ protected:
    *@param plan vector of geometry_msgs::PoseStamped
    *@param waypoint pointer to the waypoint of type geometry_msgs::PoseStamped
   */
-  void publish_visualisations(const std::vector<geometry_msgs::PoseStamped>& plan, const geometry_msgs::PoseStamped* waypoint);
+  void publishVisualisations(const std::vector<geometry_msgs::PoseStamped>& plan, const geometry_msgs::PoseStamped* waypoint);
 
 };
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <vector>
 #include <limits>
-
+#include <boost/scope_exit.hpp>
 #include "costmap_2d/costmap_2d_ros.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "mbf_msgs/GetPathResult.h"
@@ -226,11 +226,16 @@ uint32_t SmacPlannerHybrid::makePlan(
   double &cost,
   std::string &message)
 {
+
+  geometry_msgs::PoseStamped* waypoint_ptr = nullptr;
+    BOOST_SCOPE_EXIT(&plan, &waypoint_ptr, this_) {
+      this_->publish_visualisations(plan, waypoint_ptr);
+  } BOOST_SCOPE_EXIT_END
+
   std::vector<geometry_msgs::PoseStamped> goal_align_poses;
 
   PlanResult plan_result;
   uint32_t result_code;
-  geometry_msgs::PoseStamped* waypoint_ptr = nullptr;
 
   // check if the start is already under tolerance within the goal
   if (Utils::isSamePose(start.pose, goal.pose, tolerance)){
@@ -320,16 +325,16 @@ uint32_t SmacPlannerHybrid::makePlan(
       result_code = mbf_msgs::GetPathResult::INTERNAL_ERROR;
     }
   }
+  return  result_code;
+}
 
+void SmacPlannerHybrid::publish_visualisations(const std::vector<geometry_msgs::PoseStamped>& plan, const geometry_msgs::PoseStamped* waypoint_ptr) {
   nav_msgs::Path output_path;
   output_path.header.stamp = ros::Time::now();
   output_path.header.frame_id = _global_frame;
   output_path.poses = plan;
 
-  if (_final_plan_publisher.getNumSubscribers() > 0) {
-    _final_plan_publisher.publish(output_path);
-  }
-
+  _final_plan_publisher.publish(output_path);
   // plot footprint path planned for debug
   if (_planned_footprints_publisher.getNumSubscribers() > 0) {
     visualization_msgs::Marker clear_all_marker;
@@ -347,10 +352,7 @@ uint32_t SmacPlannerHybrid::makePlan(
   if (waypoint_ptr) {
     Utils::publishArrowMarker(_waypoint_publisher, * waypoint_ptr, "goal_align_waypoint", 1);
   }
-
-  return  result_code;
 }
-
 
 void SmacPlannerHybrid::collision(const geometry_msgs::Pose& robot_pose, const ros::Publisher& collision_map_publisher) {
   base_local_planner::FootprintHelper fph;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -229,7 +229,7 @@ uint32_t SmacPlannerHybrid::makePlan(
 
   geometry_msgs::PoseStamped* waypoint_ptr = nullptr;
     BOOST_SCOPE_EXIT(&plan, &waypoint_ptr, this_) {
-      this_->publish_visualisations(plan, waypoint_ptr);
+      this_->publishVisualisations(plan, waypoint_ptr);
   } BOOST_SCOPE_EXIT_END
 
   std::vector<geometry_msgs::PoseStamped> goal_align_poses;
@@ -254,81 +254,76 @@ uint32_t SmacPlannerHybrid::makePlan(
   if (_search_info.goal_align_distance <= tolerance) {
     getPath(start, goal, tolerance, plan_result);
     plan = plan_result.path();
-    cost = plan_result.cost;
-    message = plan_result.message;
-    result_code = plan_result.result_code;
+    return plan_result.result_code;
   }
 
-  else{
-    // if goal_align_distance > 0 then calculate two possible goal align poses
-    geometry_msgs::PoseStamped align_pose_front, align_pose_back;
-    align_pose_front.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose, _search_info.goal_align_distance);
-    align_pose_back.pose  = Utils::getPoseAtDistanceAlongHeading(goal.pose,  -_search_info.goal_align_distance);
+  // if goal_align_distance > 0 then calculate two possible goal align poses
+  geometry_msgs::PoseStamped align_pose_front, align_pose_back;
+  align_pose_front.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose, _search_info.goal_align_distance);
+  align_pose_back.pose  = Utils::getPoseAtDistanceAlongHeading(goal.pose,  -_search_info.goal_align_distance);
 
-    // if !allow_goal_overshoot then we select pose on the same side of goal as the robot
-    if (!_search_info.allow_goal_overshoot) {
-      if (_search_info.isStartBehindSearchBounds()) {
-        ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters back of the goal pose", _search_info.goal_align_distance);
-        goal_align_poses.push_back(align_pose_back);
-      } else {
-        ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters front of the goal pose", _search_info.goal_align_distance);
-        goal_align_poses.push_back(align_pose_front);
-      }
-    // else both
+  // if !allow_goal_overshoot then we select pose on the same side of goal as the robot
+  if (!_search_info.allow_goal_overshoot) {
+    if (_search_info.isStartBehindSearchBounds()) {
+      ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters back of the goal pose", _search_info.goal_align_distance);
+      goal_align_poses.push_back(align_pose_back);
     } else {
-      ROS_INFO_NAMED("smac_planner_hybrid", "Robot may align either %f meters before or after the goal pose", _search_info.goal_align_distance);
-      goal_align_poses = {align_pose_front, align_pose_back};
+      ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters front of the goal pose", _search_info.goal_align_distance);
+      goal_align_poses.push_back(align_pose_front);
+    }
+  // else both
+  } else {
+    ROS_INFO_NAMED("smac_planner_hybrid", "Robot may align either %f meters before or after the goal pose", _search_info.goal_align_distance);
+    goal_align_poses = {align_pose_front, align_pose_back};
+  }
+
+  // For single align pose
+  if (goal_align_poses.size() == 1) {
+    PlanResult result = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
+    plan = result.path();
+    cost = result.cost;
+    message = result.message;
+    result_code = result.result_code;
+    waypoint_ptr = &goal_align_poses[0];
+  }
+
+  // For two align poses (choose the path with smaller path length)
+  else if (goal_align_poses.size() == 2) {
+    PlanResult result_option_1 = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
+    PlanResult result_option_2 = planWithWaypoint(start, goal_align_poses[1], goal, tolerance);
+
+    if (!result_option_1.isValid() && !result_option_2.isValid()) {
+      message = "Could not plan to either of the goal align poses";
+      // use result code from the first option as the error code
+      result_code = result_option_1.result_code;
     }
 
-
-    // For single align pose
-
-    if (goal_align_poses.size() == 1) {
-      PlanResult result = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
-      plan = result.path();
-      cost = result.cost;
-      message = result.message;
-      result_code = result.result_code;
+    if (result_option_1.isValid() && (!result_option_2.isValid() || result_option_1.length() <= result_option_2.length())) {
+      // Use first option if it's valid and either the only valid option or has smaller path length
+      plan = result_option_1.path();
+      cost = result_option_1.cost;
+      message = result_option_1.message;
+      result_code = result_option_2.result_code;
       waypoint_ptr = &goal_align_poses[0];
-    }
-
-    // For two align poses (choose the path with smaller path length)
-    else if (goal_align_poses.size() == 2) {
-      PlanResult result_option_1 = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
-      PlanResult result_option_2 = planWithWaypoint(start, goal_align_poses[1], goal, tolerance);
-
-      if (!result_option_1.isValid() && !result_option_2.isValid()) {
-        message = "Could not plan to either of the goal align poses";
-        // use result code from the first option as the error code
-        result_code = result_option_1.result_code;
-      }
-
-      if (result_option_1.isValid() && (!result_option_2.isValid() || result_option_1.length() <= result_option_2.length())) {
-        // Use first option if it's valid and either the only valid option or has smaller path length
-        plan = result_option_1.path();
-        cost = result_option_1.cost;
-        message = result_option_1.message;
-        result_code = result_option_2.result_code;
-        waypoint_ptr = &goal_align_poses[0];
-      } else {
-        // Use second option
-        plan = result_option_2.path();
-        cost = result_option_2.cost;
-        message = result_option_2.message;
-        result_code = result_option_2.result_code;
-        waypoint_ptr = &goal_align_poses[1];
-      }
-    }
-
-    else {
-      ROS_ERROR_NAMED("smac_planner_hybrid", "the number of waypoints is %zu", goal_align_poses.size());
-      result_code = mbf_msgs::GetPathResult::INTERNAL_ERROR;
+    } else {
+      // Use second option
+      plan = result_option_2.path();
+      cost = result_option_2.cost;
+      message = result_option_2.message;
+      result_code = result_option_2.result_code;
+      waypoint_ptr = &goal_align_poses[1];
     }
   }
+
+  else {
+    ROS_ERROR_NAMED("smac_planner_hybrid", "the number of waypoints is %zu", goal_align_poses.size());
+    result_code = mbf_msgs::GetPathResult::INTERNAL_ERROR;
+  }
+
   return  result_code;
 }
 
-void SmacPlannerHybrid::publish_visualisations(const std::vector<geometry_msgs::PoseStamped>& plan, const geometry_msgs::PoseStamped* waypoint_ptr) {
+void SmacPlannerHybrid::publishVisualisations(const std::vector<geometry_msgs::PoseStamped>& plan, const geometry_msgs::PoseStamped* waypoint_ptr) {
   nav_msgs::Path output_path;
   output_path.header.stamp = ros::Time::now();
   output_path.header.frame_id = _global_frame;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -229,6 +229,8 @@ uint32_t SmacPlannerHybrid::makePlan(
   std::vector<geometry_msgs::PoseStamped> goal_align_poses;
 
   PlanResult plan_result;
+  uint32_t result_code;
+  geometry_msgs::PoseStamped* waypoint_ptr = nullptr;
 
   // check if the start is already under tolerance within the goal
   if (Utils::isSamePose(start.pose, goal.pose, tolerance)){
@@ -247,74 +249,76 @@ uint32_t SmacPlannerHybrid::makePlan(
   if (_search_info.goal_align_distance <= tolerance) {
     getPath(start, goal, tolerance, plan_result);
     plan = plan_result.path();
-    return plan_result.result_code;
+    cost = plan_result.cost;
+    message = plan_result.message;
+    result_code = plan_result.result_code;
   }
 
-  // if goal_align_distance > 0 then calculate two possible goal align poses
-  geometry_msgs::PoseStamped align_pose_front, align_pose_back;
-  align_pose_front.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose, _search_info.goal_align_distance);
-  align_pose_back.pose  = Utils::getPoseAtDistanceAlongHeading(goal.pose,  -_search_info.goal_align_distance);
+  else{
+    // if goal_align_distance > 0 then calculate two possible goal align poses
+    geometry_msgs::PoseStamped align_pose_front, align_pose_back;
+    align_pose_front.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose, _search_info.goal_align_distance);
+    align_pose_back.pose  = Utils::getPoseAtDistanceAlongHeading(goal.pose,  -_search_info.goal_align_distance);
 
-  // if !allow_goal_overshoot then we select pose on the same side of goal as the robot
-  if (!_search_info.allow_goal_overshoot) {
-    if (_search_info.isStartBehindSearchBounds()) {
-      ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters back of the goal pose", _search_info.goal_align_distance);
-      goal_align_poses.push_back(align_pose_back);
+    // if !allow_goal_overshoot then we select pose on the same side of goal as the robot
+    if (!_search_info.allow_goal_overshoot) {
+      if (_search_info.isStartBehindSearchBounds()) {
+        ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters back of the goal pose", _search_info.goal_align_distance);
+        goal_align_poses.push_back(align_pose_back);
+      } else {
+        ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters front of the goal pose", _search_info.goal_align_distance);
+        goal_align_poses.push_back(align_pose_front);
+      }
+    // else both
     } else {
-      ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters front of the goal pose", _search_info.goal_align_distance);
-      goal_align_poses.push_back(align_pose_front);
-    }
-  // else both
-  } else {
-    ROS_INFO_NAMED("smac_planner_hybrid", "Robot may align either %f meters before or after the goal pose", _search_info.goal_align_distance);
-    goal_align_poses = {align_pose_front, align_pose_back};
-  }
-
-
-  // For single align pose
-  uint32_t result_code;
-  geometry_msgs::PoseStamped* waypoint_ptr;
-
-  if (goal_align_poses.size() == 1) {
-    PlanResult result = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
-    plan = result.path();
-    cost = result.cost;
-    message = result.message;
-    result_code = result.result_code;
-    waypoint_ptr = &goal_align_poses[0];
-  }
-
-  // For two align poses (choose the path with smaller path length)
-  else if (goal_align_poses.size() == 2) {
-    PlanResult result_option_1 = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
-    PlanResult result_option_2 = planWithWaypoint(start, goal_align_poses[1], goal, tolerance);
-
-    if (!result_option_1.isValid() && !result_option_2.isValid()) {
-      message = "Could not plan to either of the goal align poses";
-      // use result code from the first option as the error code
-      result_code = result_option_1.result_code;
+      ROS_INFO_NAMED("smac_planner_hybrid", "Robot may align either %f meters before or after the goal pose", _search_info.goal_align_distance);
+      goal_align_poses = {align_pose_front, align_pose_back};
     }
 
-    if (result_option_1.isValid() && (!result_option_2.isValid() || result_option_1.length() <= result_option_2.length())) {
-      // Use first option if it's valid and either the only valid option or has smaller path length
-      plan = result_option_1.path();
-      cost = result_option_1.cost;
-      message = result_option_1.message;
-      result_code = result_option_2.result_code;
+
+    // For single align pose
+
+    if (goal_align_poses.size() == 1) {
+      PlanResult result = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
+      plan = result.path();
+      cost = result.cost;
+      message = result.message;
+      result_code = result.result_code;
       waypoint_ptr = &goal_align_poses[0];
-    } else {
-      // Use second option
-      plan = result_option_2.path();
-      cost = result_option_2.cost;
-      message = result_option_2.message;
-      result_code = result_option_2.result_code;
-      waypoint_ptr = &goal_align_poses[1];
     }
-  }
 
-  else {
-    ROS_ERROR_NAMED("smac_planner_hybrid", "the number of waypoints is %zu", goal_align_poses.size());
-    result_code = mbf_msgs::GetPathResult::INTERNAL_ERROR;
+    // For two align poses (choose the path with smaller path length)
+    else if (goal_align_poses.size() == 2) {
+      PlanResult result_option_1 = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
+      PlanResult result_option_2 = planWithWaypoint(start, goal_align_poses[1], goal, tolerance);
+
+      if (!result_option_1.isValid() && !result_option_2.isValid()) {
+        message = "Could not plan to either of the goal align poses";
+        // use result code from the first option as the error code
+        result_code = result_option_1.result_code;
+      }
+
+      if (result_option_1.isValid() && (!result_option_2.isValid() || result_option_1.length() <= result_option_2.length())) {
+        // Use first option if it's valid and either the only valid option or has smaller path length
+        plan = result_option_1.path();
+        cost = result_option_1.cost;
+        message = result_option_1.message;
+        result_code = result_option_2.result_code;
+        waypoint_ptr = &goal_align_poses[0];
+      } else {
+        // Use second option
+        plan = result_option_2.path();
+        cost = result_option_2.cost;
+        message = result_option_2.message;
+        result_code = result_option_2.result_code;
+        waypoint_ptr = &goal_align_poses[1];
+      }
+    }
+
+    else {
+      ROS_ERROR_NAMED("smac_planner_hybrid", "the number of waypoints is %zu", goal_align_poses.size());
+      result_code = mbf_msgs::GetPathResult::INTERNAL_ERROR;
+    }
   }
 
   nav_msgs::Path output_path;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -228,8 +228,8 @@ uint32_t SmacPlannerHybrid::makePlan(
   std::string &message)
 {
   geometry_msgs::PoseStamped* waypoint_ptr = nullptr;
-    BOOST_SCOPE_EXIT(&plan, &waypoint_ptr, this_) {
-      this_->publishVisualisations(plan, waypoint_ptr);
+  BOOST_SCOPE_EXIT(&plan, &waypoint_ptr, this_) {
+    this_->publishVisualisations(plan, waypoint_ptr);
   } BOOST_SCOPE_EXIT_END
 
   std::vector<geometry_msgs::PoseStamped> goal_align_poses;
@@ -349,6 +349,7 @@ void SmacPlannerHybrid::publishVisualisations(const std::vector<geometry_msgs::P
     Utils::publishArrowMarker(_waypoint_publisher, * waypoint_ptr, "goal_align_waypoint", 1);
   }
 }
+
 
 void SmacPlannerHybrid::collision(const geometry_msgs::Pose& robot_pose, const ros::Publisher& collision_map_publisher) {
   base_local_planner::FootprintHelper fph;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <limits>
 #include <boost/scope_exit.hpp>
+
 #include "costmap_2d/costmap_2d_ros.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "mbf_msgs/GetPathResult.h"
@@ -226,7 +227,6 @@ uint32_t SmacPlannerHybrid::makePlan(
   double &cost,
   std::string &message)
 {
-
   geometry_msgs::PoseStamped* waypoint_ptr = nullptr;
     BOOST_SCOPE_EXIT(&plan, &waypoint_ptr, this_) {
       this_->publishVisualisations(plan, waypoint_ptr);
@@ -235,6 +235,7 @@ uint32_t SmacPlannerHybrid::makePlan(
   std::vector<geometry_msgs::PoseStamped> goal_align_poses;
 
   PlanResult plan_result;
+
   // check if the start is already under tolerance within the goal
   if (Utils::isSamePose(start.pose, goal.pose, tolerance)){
     ROS_INFO_NAMED("smac_planner_hybrid", "Start and goal same or goal under tolerance");

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -235,8 +235,6 @@ uint32_t SmacPlannerHybrid::makePlan(
   std::vector<geometry_msgs::PoseStamped> goal_align_poses;
 
   PlanResult plan_result;
-  uint32_t result_code;
-
   // check if the start is already under tolerance within the goal
   if (Utils::isSamePose(start.pose, goal.pose, tolerance)){
     ROS_INFO_NAMED("smac_planner_hybrid", "Start and goal same or goal under tolerance");
@@ -278,6 +276,8 @@ uint32_t SmacPlannerHybrid::makePlan(
   }
 
   // For single align pose
+  uint32_t result_code;
+
   if (goal_align_poses.size() == 1) {
     PlanResult result = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
     plan = result.path();


### PR DESCRIPTION
part of: [AB#77603](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/77603)

Because of early return, there was no visualisation message published when goal align distance = 0, removed early return from  the condition
  if (_search_info.goal_align_distance <= tolerance) {
  }
  
  and added else case, now visualisation is published after the else case.