### PR TITLE
fix: planning_canceled flag is reset in second segment

### DIFF
--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -227,6 +227,8 @@ uint32_t SmacPlannerHybrid::makePlan(
   double &cost,
   std::string &message)
 {
+  _planning_canceled = false;
+
   geometry_msgs::PoseStamped* waypoint_ptr = nullptr;
   BOOST_SCOPE_EXIT(&plan, &waypoint_ptr, this_) {
     this_->publishVisualisations(plan, waypoint_ptr);
@@ -424,7 +426,6 @@ void SmacPlannerHybrid::getPath(
     const double& tolerance,
     PlanResult& plan_result)
 {
-  _planning_canceled = false;
 
   std::lock_guard<std::mutex> lock_reinit(_mutex);
   ros::Time a = ros::Time::now();

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -426,7 +426,6 @@ void SmacPlannerHybrid::getPath(
     const double& tolerance,
     PlanResult& plan_result)
 {
-
   std::lock_guard<std::mutex> lock_reinit(_mutex);
   ros::Time a = ros::Time::now();
 


### PR DESCRIPTION
when goal_align_distance is > 0, we use the planWithWaypoint function. This calls the getPath two times and in the second time it will reset the flag and return the path of second segment.
<img width="1169" height="943" alt="image" src="https://github.com/user-attachments/assets/a1abc342-82d1-48d9-a763-2519b828e1cd" />

