### PR TITLE
fix: when first segment fails, it sometimes returns path of second segment

### DIFF
--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -555,6 +555,7 @@ void SmacPlannerHybrid::getPath(
       plan_result.result_code = mbf_msgs::GetPathResult::BLOCKED_START;
       return;
     }
+    plan_result.result_code = result;
 
     if (result == mbf_msgs::GetPathResult::CANCELED) {
       plan_result.message = "Planner was cancelled";
@@ -567,10 +568,7 @@ void SmacPlannerHybrid::getPath(
     } else {
       plan_result.message = "No valid path found";
       plan_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
-      return;
     }
-    plan_result.result_code = result;
-    return;
   }
 
   // Convert to world coordinates

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -567,6 +567,7 @@ void SmacPlannerHybrid::getPath(
     } else {
       plan_result.message = "No valid path found";
       plan_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
+      return;
     }
     plan_result.result_code = result;
     return;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -559,19 +559,17 @@ void SmacPlannerHybrid::getPath(
 
     if (result == mbf_msgs::GetPathResult::CANCELED) {
       plan_result.message = "Planner was cancelled";
-      plan_result.result_code = mbf_msgs::GetPathResult::CANCELED;
     }
     else if (result == mbf_msgs::GetPathResult::PAT_EXCEEDED) {
       plan_result.message = "Exceeded maximum planning time";
-      plan_result.result_code = mbf_msgs::GetPathResult::PAT_EXCEEDED;
     }
     else if (num_iterations >= _a_star->getMaxIterations()) {
       plan_result.message = "Exceeded maximum iterations";
-      plan_result.result_code = mbf_msgs::GetPathResult::PAT_EXCEEDED;
     } else {
       plan_result.message = "No valid path found";
       plan_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
     }
+    plan_result.result_code = result;
     return;
   }
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -570,7 +570,6 @@ void SmacPlannerHybrid::getPath(
       plan_result.message = "No valid path found";
       plan_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
     }
-    // return;
   }
 
   // Convert to world coordinates
@@ -623,8 +622,6 @@ void SmacPlannerHybrid::getPath(
     " milliseconds to smooth path." << std::endl;
 #endif
   plan_result.setPath(output_path.poses);
-  // plan_result.result_code = mbf_msgs::GetPathResult::SUCCESS;
-  // return;
 }
 
 bool SmacPlannerHybrid::cancel() {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License. Reserved.
 
+#include <iostream>
 #include <string>
 #include <memory>
 #include <vector>
@@ -558,14 +559,18 @@ void SmacPlannerHybrid::getPath(
 
     if (result == mbf_msgs::GetPathResult::CANCELED) {
       plan_result.message = "Planner was cancelled";
+      plan_result.result_code = mbf_msgs::GetPathResult::CANCELED;
     }
     else if (result == mbf_msgs::GetPathResult::PAT_EXCEEDED) {
       plan_result.message = "Exceeded maximum planning time";
+      plan_result.result_code = mbf_msgs::GetPathResult::PAT_EXCEEDED;
     }
     else if (num_iterations >= _a_star->getMaxIterations()) {
       plan_result.message = "Exceeded maximum iterations";
+      plan_result.result_code = mbf_msgs::GetPathResult::PAT_EXCEEDED;
     } else {
       plan_result.message = "No valid path found";
+      plan_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
     }
     return;
   }

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -565,10 +565,12 @@ void SmacPlannerHybrid::getPath(
     }
     else if (num_iterations >= _a_star->getMaxIterations()) {
       plan_result.message = "Exceeded maximum iterations";
+      plan_result.result_code = mbf_msgs::GetPathResult::PAT_EXCEEDED;
     } else {
       plan_result.message = "No valid path found";
       plan_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
     }
+    return;
   }
 
   // Convert to world coordinates

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -570,7 +570,7 @@ void SmacPlannerHybrid::getPath(
       plan_result.message = "No valid path found";
       plan_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
     }
-    return;
+    // return;
   }
 
   // Convert to world coordinates
@@ -623,8 +623,8 @@ void SmacPlannerHybrid::getPath(
     " milliseconds to smooth path." << std::endl;
 #endif
   plan_result.setPath(output_path.poses);
-  plan_result.result_code = mbf_msgs::GetPathResult::SUCCESS;
-  return;
+  // plan_result.result_code = mbf_msgs::GetPathResult::SUCCESS;
+  // return;
 }
 
 bool SmacPlannerHybrid::cancel() {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License. Reserved.
 
-#include <iostream>
 #include <string>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
Consequence:
<img width="1116" height="779" alt="image" src="https://github.com/user-attachments/assets/f2778d85-1c67-4394-b256-af8b1dafeb01" />

The message was no valid path found but result code was not updated (it was still success), so in the  + operator, when it checked if the segments are valid it would pass and then add them (but one of was not valid).

<img width="697" height="235" alt="image" src="https://github.com/user-attachments/assets/17dd131d-1125-4801-8d52-b52e0dcfe372" />
