### PR TITLE
fix: planning fails when start and waypoint are same

### DIFF
--- a/include/smac_planner/node_hybrid.hpp
+++ b/include/smac_planner/node_hybrid.hpp
@@ -25,7 +25,6 @@
 #include <utility>
 #include <limits>
 
-#include "geometry_msgs/PoseStamped.h"
 #include "ompl/base/StateSpace.h"
 
 #include "smac_planner/constants.hpp"

--- a/include/smac_planner/node_hybrid.hpp
+++ b/include/smac_planner/node_hybrid.hpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <limits>
 
+#include "costmap_2d/costmap_2d.h"
 #include "ompl/base/StateSpace.h"
 
 #include "smac_planner/constants.hpp"
@@ -399,7 +400,8 @@ public:
 
   static bool arePosesSameDiscreteState(
     const geometry_msgs::Pose& pose1,
-    const geometry_msgs::Pose& pose2
+    const geometry_msgs::Pose& pose2,
+    costmap_2d::Costmap2D* costmap
   );
 
   /**

--- a/include/smac_planner/node_hybrid.hpp
+++ b/include/smac_planner/node_hybrid.hpp
@@ -25,6 +25,7 @@
 #include <utility>
 #include <limits>
 
+#include "geometry_msgs/PoseStamped.h"
 #include "ompl/base/StateSpace.h"
 
 #include "smac_planner/constants.hpp"
@@ -396,6 +397,11 @@ public:
     const MotionModel & motion_model,
     const unsigned int & dim_3_size,
     const SearchInfo & search_info);
+
+  static bool arePosesSameDiscreteState(
+    const geometry_msgs::Pose& pose1,
+    const geometry_msgs::Pose& pose2
+  );
 
   /**
    * @brief Compute the Obstacle heuristic

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -132,12 +132,6 @@ protected:
     const geometry_msgs::PoseStamped& goal,
     const double& tolerance);
 
-
-  bool arePosesSameDiscreteState(
-    const geometry_msgs::Pose& pose1,
-    const geometry_msgs::Pose& pose2,
-    costmap_2d::Costmap2D* costmap) const;
-
   std::unique_ptr<dynamic_reconfigure::Server<SmacPlannerHybridConfig>> dsrv_;
 
   std::unique_ptr<AStarAlgorithm<NodeHybrid>> _a_star;

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -132,6 +132,12 @@ protected:
     const geometry_msgs::PoseStamped& goal,
     const double& tolerance);
 
+
+  bool arePosesSameDiscreteState(
+    const geometry_msgs::Pose& pose1,
+    const geometry_msgs::Pose& pose2,
+    costmap_2d::Costmap2D* costmap) const;
+
   std::unique_ptr<dynamic_reconfigure::Server<SmacPlannerHybridConfig>> dsrv_;
 
   std::unique_ptr<AStarAlgorithm<NodeHybrid>> _a_star;

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -156,6 +156,8 @@ protected:
   ros::Publisher _collision_pub;
   std::mutex _mutex;
 
+  std::vector<geometry_msgs::PoseStamped> computeWaypoints(const geometry_msgs::PoseStamped& start, const geometry_msgs::PoseStamped& goal, float tolerance);
+
   /**
    *@brief publishes the visualisations like path, waypoint, footprints. To be called at end of the planning
    *@param plan vector of geometry_msgs::PoseStamped

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -20,7 +20,7 @@
 #include <limits>
 #include <utility>
 
-#include "geometry_msgs/Pose.h"
+// #include "geometry_msgs/Pose.h"
 #include "ompl/base/ScopedState.h"
 #include "ompl/base/spaces/DubinsStateSpace.h"
 #include "ompl/base/spaces/ReedsSheppStateSpace.h"

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -20,9 +20,11 @@
 #include <limits>
 #include <utility>
 
+#include "geometry_msgs/Pose.h"
 #include "ompl/base/ScopedState.h"
 #include "ompl/base/spaces/DubinsStateSpace.h"
 #include "ompl/base/spaces/ReedsSheppStateSpace.h"
+#include "tf2/utils.h"
 
 #include "smac_planner/node_hybrid.hpp"
 
@@ -375,6 +377,8 @@ bool NodeHybrid::isNodeValid(
   return true;
 }
 
+
+
 float NodeHybrid::getTraversalCost(const NodePtr & child)
 {
   const float normalized_cost = child->getCost() / 252.0f;
@@ -469,6 +473,27 @@ inline float distanceHeuristic2D(
   int dx = static_cast<int>(idx % size_x) - static_cast<int>(target_x);
   int dy = static_cast<int>(idx / size_x) - static_cast<int>(target_y);
   return std::sqrt(dx * dx + dy * dy);
+}
+
+bool NodeHybrid::arePosesSameDiscreteState(
+  const geometry_msgs::Pose& pose1,
+  const geometry_msgs::Pose& pose2)
+{
+  unsigned int pose1_mx, pose1_my, pose2_mx, pose2_my;
+  const costmap_2d::Costmap2D* costmap = costmap_ros->getCostmap();
+
+  // Convert world coordinates to map coordinates
+  costmap->worldToMap(pose1.position.x, pose1.position.y, pose1_mx, pose1_my);
+  costmap->worldToMap(pose2.position.x, pose2.position.y, pose2_mx, pose2_my);
+
+  // Get orientation bins
+  const unsigned int pose1_bin_id = NodeHybrid::motion_table.getClosestAngularBin(tf2::getYaw(pose1.orientation));
+  const unsigned int pose2_bin_id = NodeHybrid::motion_table.getClosestAngularBin(tf2::getYaw(pose2.orientation));
+
+  // Check if they map to the same discrete planning state
+  return (pose1_mx == pose2_mx &&
+          pose1_my == pose2_my &&
+          pose1_bin_id == pose2_bin_id);
 }
 
 void NodeHybrid::resetObstacleHeuristic(

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -21,6 +21,7 @@
 #include <utility>
 
 // #include "geometry_msgs/Pose.h"
+#include "costmap_2d/costmap_2d.h"
 #include "ompl/base/ScopedState.h"
 #include "ompl/base/spaces/DubinsStateSpace.h"
 #include "ompl/base/spaces/ReedsSheppStateSpace.h"
@@ -475,10 +476,10 @@ inline float distanceHeuristic2D(
 
 bool NodeHybrid::arePosesSameDiscreteState(
   const geometry_msgs::Pose& pose1,
-  const geometry_msgs::Pose& pose2)
+  const geometry_msgs::Pose& pose2,
+  costmap_2d::Costmap2D* costmap)
 {
   unsigned int pose1_mx, pose1_my, pose2_mx, pose2_my;
-  const costmap_2d::Costmap2D* costmap = costmap_ros->getCostmap();
 
   // Convert world coordinates to map coordinates
   costmap->worldToMap(pose1.position.x, pose1.position.y, pose1_mx, pose1_my);

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -377,8 +377,6 @@ bool NodeHybrid::isNodeValid(
   return true;
 }
 
-
-
 float NodeHybrid::getTraversalCost(const NodePtr & child)
 {
   const float normalized_cost = child->getCost() / 252.0f;

--- a/src/node_hybrid.cpp
+++ b/src/node_hybrid.cpp
@@ -20,7 +20,6 @@
 #include <limits>
 #include <utility>
 
-// #include "geometry_msgs/Pose.h"
 #include "costmap_2d/costmap_2d.h"
 #include "ompl/base/ScopedState.h"
 #include "ompl/base/spaces/DubinsStateSpace.h"

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -238,39 +238,25 @@ std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(cons
 
   std::vector<geometry_msgs::PoseStamped> waypoints;
 
+  const bool can_use_front_waypoint = !NodeHybrid::arePosesSameDiscreteState(waypoint_front.pose, start.pose, _costmap);
+  const bool can_use_back_waypoint = !NodeHybrid::arePosesSameDiscreteState(waypoint_back.pose, start.pose, _costmap);
 
-  bool front_waypt_is_same_as_start = NodeHybrid::arePosesSameDiscreteState(waypoint_front.pose, start.pose, _costmap);
-  bool back_waypt_is_same_as_start= NodeHybrid::arePosesSameDiscreteState(waypoint_back.pose, start.pose, _costmap);
+  ROS_WARN_COND_NAMED(!can_use_back_waypoint, "smac_planner_hybrid", "front waypoint same as start");
+  ROS_WARN_COND_NAMED(!can_use_front_waypoint, "smac_planner_hybrid", "back_waypoint is same as start");
 
   if (!_search_info.allow_goal_overshoot) {
-    if (_search_info.isStartBehindSearchBounds()) {
+    if (_search_info.isStartBehindSearchBounds() && can_use_back_waypoint) {
       ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters back of the goal pose", _search_info.goal_align_distance);
-      if (!back_waypt_is_same_as_start) {
         waypoints.push_back(waypoint_back);
-      }
-      else {
-        ROS_WARN_NAMED("smac_planner_hybrid", "front waypoint same as start");
-      }
-    } else {
+    }
+    else if (can_use_front_waypoint) {
       ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is align %f meters front of the goal pose", _search_info.goal_align_distance);
-      if (!front_waypt_is_same_as_start) {
         waypoints.push_back(waypoint_front);
-      }
-      else {
-        ROS_WARN_NAMED("smac_planner_hybrid", "back_waypoint is same as start");
-      }
     }
-  // Else both (if they're different from start pose)
-  } else {
+  } else if (can_use_front_waypoint && can_use_back_waypoint){
     ROS_INFO_NAMED("smac_planner_hybrid", "found two waypoint, %f meters before and after the goal pose", _search_info.goal_align_distance);
-    if (!front_waypt_is_same_as_start) {
-      waypoints.push_back(waypoint_front);
-    }
-    if (!back_waypt_is_same_as_start) {
-      waypoints.push_back(waypoint_back);
-    }
+      waypoints = {waypoint_front, waypoint_back};
   }
-
   return waypoints;
 }
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -313,7 +313,6 @@ uint32_t SmacPlannerHybrid::makePlan(
 
   // If no waypoint, proceed with normal planning
   if (waypoints.size() ==0) {
-    ROS_INFO_NAMED("smac_planner_hybrid", "No waypoint... ");
     getPath(start, goal, tolerance, plan_result);
     plan = plan_result.path();
     return plan_result.result_code;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -202,9 +202,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
 {
   // Get the costmap (downsampled if needed)
   costmap_2d::Costmap2D* costmap = _costmap;
-  if (_costmap_downsampler) {
-    costmap = _costmap_downsampler->downsample(_config.downsampling_factor);
-  }
+
   // Check if start and waypoint are the same in discrete planning space
   bool same_discrete_state = arePosesSameDiscreteState(start.pose, waypoint.pose, costmap); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
   bool within_tolerance = tolerance > 0 && Utils::isSamePose(start.pose, waypoint.pose, tolerance);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -15,11 +15,13 @@
 
 #include <string>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <limits>
 #include <boost/scope_exit.hpp>
 
 #include "costmap_2d/costmap_2d_ros.h"
+#include "geometry_msgs/Pose.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "mbf_msgs/GetPathResult.h"
 #include "nav_msgs/Path.h"
@@ -182,23 +184,22 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   costmap_2d::Costmap2D* costmap = _costmap;
 
   // Check if start and waypoint are the same in discrete planning space
-  bool same_discrete_state = NodeHybrid::arePosesSameDiscreteState(start.pose, waypoint.pose, costmap); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
-  bool within_tolerance = tolerance > 0 && Utils::isSamePose(start.pose, waypoint.pose, tolerance);
+  // bool same_discrete_state = NodeHybrid::arePosesSameDiscreteState(start.pose, waypoint.pose, costmap); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
+  // bool within_tolerance = tolerance > 0 && Utils::isSamePose(start.pose, waypoint.pose, tolerance);
 
-  if (same_discrete_state || within_tolerance) {
-    ROS_WARN_NAMED("smac_planner_hybrid",
-      "Start and waypoint map to same discrete state, skipping waypoint and planning from start to goal");
-    if (!_search_info.allow_goal_overshoot) {
-      _search_info.setSearchBound(goal_pose.pose);
-      _search_info.setStart(start.pose.position);
-      _a_star->setSearchBounds(goal_pose.pose, start.pose.position, _search_info.allow_goal_overshoot);
-    }
-    PlanResult result;
-    getPath(start, goal_pose, tolerance, result);
-    return result;
-  }
+  // if (same_discrete_state || within_tolerance) {
+  //   ROS_WARN_NAMED("smac_planner_hybrid",
+  //     "Start and waypoint map to same discrete state, skipping waypoint and planning from start to goal");
+  //   if (!_search_info.allow_goal_overshoot) {
+  //     _search_info.setSearchBound(goal_pose.pose);
+  //     _search_info.setStart(start.pose.position);
+  //     _a_star->setSearchBounds(goal_pose.pose, start.pose.position, _search_info.allow_goal_overshoot);
+  //   }
+  //   PlanResult result;
+  //   getPath(start, goal_pose, tolerance, result);
+  //   return result;
+  // }
 
-  // Normal case: start and waypoint are different in discrete space
   if (!_search_info.allow_goal_overshoot) {
     _search_info.setSearchBound(goal_pose.pose);
     _search_info.setStart(waypoint.pose.position);
@@ -240,6 +241,59 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   return result;
 }
 
+std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(const geometry_msgs::PoseStamped& start, const geometry_msgs::PoseStamped& goal, float tolerance) {
+
+  std::cout << "\n\n goal_align_distance : " << _search_info.goal_align_distance << "\n\n";
+  std::cout << "\n\n allow_goal_overshoot: " << _search_info.allow_goal_overshoot << "\n\n";
+  if (_search_info.goal_align_distance <= tolerance) {
+    return {};
+  }
+
+  geometry_msgs::PoseStamped waypoint_front;
+  geometry_msgs::PoseStamped waypoint_back;
+  waypoint_front.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose, _search_info.goal_align_distance);
+  waypoint_back.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose,  -_search_info.goal_align_distance);
+  waypoint_front.header = goal.header;
+  waypoint_back.header = goal.header;
+
+  std::vector<geometry_msgs::PoseStamped> waypoints;
+
+
+  bool front_waypt_is_same_as_start = NodeHybrid::arePosesSameDiscreteState(waypoint_front.pose, start.pose, _costmap);
+  bool back_waypt_is_same_as_start= NodeHybrid::arePosesSameDiscreteState(waypoint_back.pose, start.pose, _costmap);
+
+  if (!_search_info.allow_goal_overshoot) {
+    if (_search_info.isStartBehindSearchBounds()) {
+      ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters back of the goal pose", _search_info.goal_align_distance);
+      if (!back_waypt_is_same_as_start) {
+        waypoints.push_back(waypoint_back);
+      }
+      else {
+        ROS_WARN_NAMED("smac_planner_hybrid", "front waypoint same as start");
+      }
+    } else {
+      ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is align %f meters front of the goal pose", _search_info.goal_align_distance);
+      if (!front_waypt_is_same_as_start) {
+        waypoints.push_back(waypoint_front);
+      }
+      else {
+        ROS_WARN_NAMED("smac_planner_hybrid", "back_waypoint is same as start");
+      }
+    }
+  // Else both (if they're different from start pose)
+  } else {
+    ROS_INFO_NAMED("smac_planner_hybrid", "found two waypoint, %f meters before and after the goal pose", _search_info.goal_align_distance);
+    if (!front_waypt_is_same_as_start) {
+      waypoints.push_back(waypoint_front);
+    }
+    if (!back_waypt_is_same_as_start) {
+      waypoints.push_back(waypoint_back);
+    }
+  }
+
+  return waypoints;
+}
+
 
 uint32_t SmacPlannerHybrid::makePlan(
   const geometry_msgs::PoseStamped & start,
@@ -256,9 +310,8 @@ uint32_t SmacPlannerHybrid::makePlan(
     this_->publishVisualisations(plan, waypoint_ptr);
   } BOOST_SCOPE_EXIT_END
 
-  std::vector<geometry_msgs::PoseStamped> goal_align_poses;
-
   PlanResult plan_result;
+
 
   // check if the start is already under tolerance within the goal
   if (Utils::isSamePose(start.pose, goal.pose, tolerance)){
@@ -273,49 +326,32 @@ uint32_t SmacPlannerHybrid::makePlan(
     _a_star->setSearchBounds(goal.pose, start.pose.position, _search_info.allow_goal_overshoot);
   }
 
-  // If goal_align_distance less than or equal to tolerance, proceed with normal planning
-  if (_search_info.goal_align_distance <= tolerance) {
+  std::vector<geometry_msgs::PoseStamped> waypoints = computeWaypoints(start, goal, tolerance);
+
+  // If no waypoint, proceed with normal planning
+  if (waypoints.size() ==0) {
+    ROS_INFO_NAMED("smac_planner_hybrid", "No waypoint... ");
     getPath(start, goal, tolerance, plan_result);
     plan = plan_result.path();
     return plan_result.result_code;
   }
 
-  // if goal_align_distance > 0 then calculate two possible goal align poses
-  geometry_msgs::PoseStamped align_pose_front, align_pose_back;
-  align_pose_front.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose, _search_info.goal_align_distance);
-  align_pose_back.pose  = Utils::getPoseAtDistanceAlongHeading(goal.pose,  -_search_info.goal_align_distance);
-
-  // if !allow_goal_overshoot then we select pose on the same side of goal as the robot
-  if (!_search_info.allow_goal_overshoot) {
-    if (_search_info.isStartBehindSearchBounds()) {
-      ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters back of the goal pose", _search_info.goal_align_distance);
-      goal_align_poses.push_back(align_pose_back);
-    } else {
-      ROS_INFO_NAMED("smac_planner_hybrid", "Robot will align %f meters front of the goal pose", _search_info.goal_align_distance);
-      goal_align_poses.push_back(align_pose_front);
-    }
-  // else both
-  } else {
-    ROS_INFO_NAMED("smac_planner_hybrid", "Robot may align either %f meters before or after the goal pose", _search_info.goal_align_distance);
-    goal_align_poses = {align_pose_front, align_pose_back};
-  }
-
-  // For single align pose
   uint32_t result_code;
 
-  if (goal_align_poses.size() == 1) {
-    PlanResult result = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
+  // For single align waypoint
+  if (waypoints.size() == 1) {
+    PlanResult result = planWithWaypoint(start, waypoints[0], goal, tolerance);
     plan = result.path();
     cost = result.cost;
     message = result.message;
     result_code = result.result_code;
-    waypoint_ptr = &goal_align_poses[0];
+    waypoint_ptr = &waypoints[0];
   }
 
-  // For two align poses (choose the path with smaller path length)
-  else if (goal_align_poses.size() == 2) {
-    PlanResult result_option_1 = planWithWaypoint(start, goal_align_poses[0], goal, tolerance);
-    PlanResult result_option_2 = planWithWaypoint(start, goal_align_poses[1], goal, tolerance);
+  // For two waypoints (choose the path with smaller path length)
+  else if (waypoints.size() == 2) {
+    PlanResult result_option_1 = planWithWaypoint(start, waypoints[0], goal, tolerance);
+    PlanResult result_option_2 = planWithWaypoint(start, waypoints[1], goal, tolerance);
 
     if (!result_option_1.isValid() && !result_option_2.isValid()) {
       message = "Could not plan to either of the goal align poses";
@@ -329,19 +365,19 @@ uint32_t SmacPlannerHybrid::makePlan(
       cost = result_option_1.cost;
       message = result_option_1.message;
       result_code = result_option_2.result_code;
-      waypoint_ptr = &goal_align_poses[0];
+      waypoint_ptr = &waypoints[0];
     } else {
       // Use second option
       plan = result_option_2.path();
       cost = result_option_2.cost;
       message = result_option_2.message;
       result_code = result_option_2.result_code;
-      waypoint_ptr = &goal_align_poses[1];
+      waypoint_ptr = &waypoints[1];
     }
   }
 
   else {
-    ROS_ERROR_NAMED("smac_planner_hybrid", "the number of waypoints is %zu", goal_align_poses.size());
+    ROS_ERROR_NAMED("smac_planner_hybrid", "the number of waypoints is %zu", waypoints.size());
     result_code = mbf_msgs::GetPathResult::INTERNAL_ERROR;
   }
 
@@ -373,7 +409,6 @@ void SmacPlannerHybrid::publishVisualisations(const std::vector<geometry_msgs::P
     Utils::publishArrowMarker(_waypoint_publisher, * waypoint_ptr, "goal_align_waypoint", 1);
   }
 }
-
 
 void SmacPlannerHybrid::collision(const geometry_msgs::Pose& robot_pose, const ros::Publisher& collision_map_publisher) {
   base_local_planner::FootprintHelper fph;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -171,58 +171,6 @@ void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t 
     _config.tolerance, toString(_motion_model).c_str());
 }
 
-// PlanResult SmacPlannerHybrid::planWithWaypoint(
-//   const geometry_msgs::PoseStamped& start,
-//   const geometry_msgs::PoseStamped& waypoint,
-//   const geometry_msgs::PoseStamped& goal_pose,
-//   const double& tolerance)
-// {
-//   if (!_search_info.allow_goal_overshoot){
-//   _search_info.setSearchBound(goal_pose.pose);
-//   _search_info.setStart(waypoint.pose.position);
-//   _a_star->setSearchBounds(goal_pose.pose, waypoint.pose.position,  _search_info.allow_goal_overshoot);
-//   }
-
-//   PlanResult segment2;
-//   if (Utils::isSamePose(start.pose, waypoint.pose, tolerance)){
-//     getPath(start, goal_pose, tolerance, segment2);
-//     return segment2;
-//   }
-
-//   // waypoint to goal pose
-//   getPath(waypoint, goal_pose, tolerance, segment2);
-//   if (!segment2.isValid())
-//   {
-//     // the segment is from waypoint to goal pose, so blocked start means blocked waypoint.
-//     if (segment2.result_code == mbf_msgs::GetPathResult::BLOCKED_START) {
-//       segment2.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
-//       ROS_ERROR_NAMED("smac_planner_hybrid", "waypoint pose is blocked");
-//       segment2.message = "Waypoint pose is blocked";
-//     }
-//     return segment2;
-//   }
-
-//   // if the robot is not between the goal and the waypoint, then we set the search bounds to the waypoint.
-//   const bool is_robot_between_goal_and_waypoint = Utils::isBetweenPoints(start.pose, waypoint.pose, goal_pose.pose);
-//   if (!is_robot_between_goal_and_waypoint){
-//     _search_info.setSearchBound(waypoint.pose);
-//     _search_info.setStart(start.pose.position);
-//     _a_star->setSearchBounds(waypoint.pose, start.pose.position,  _search_info.allow_goal_overshoot);
-//   }
-
-//   // robot_pose to waypoint
-//   PlanResult segment1;
-//   getPath(start, waypoint, tolerance, segment1);
-
-//   if (!segment1.isValid())
-//   {
-//     return segment1;
-//   }
-
-//   const PlanResult result = segment1 + segment2;
-//   return result;
-// }
-
 PlanResult SmacPlannerHybrid::planWithWaypoint(
   const geometry_msgs::PoseStamped& start,
   const geometry_msgs::PoseStamped& waypoint,

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -82,28 +82,6 @@ void SmacPlannerHybrid::initialize(
   dsrv_->setCallback(boost::bind(&SmacPlannerHybrid::reconfigureCB, this, _1, _2));
 }
 
-bool SmacPlannerHybrid::arePosesSameDiscreteState(
-  const geometry_msgs::Pose& pose1,
-  const geometry_msgs::Pose& pose2,
-  costmap_2d::Costmap2D* costmap) const
-{
-  // Convert world coordinates to map coordinates
-  float pose1_mx, pose1_my, pose2_mx, pose2_my;
-  costmap->worldToMapContinuous(pose1.position.x, pose1.position.y, pose1_mx, pose1_my);
-  costmap->worldToMapContinuous(pose2.position.x, pose2.position.y, pose2_mx, pose2_my);
-
-  // Get orientation bins (using NodeHybrid's method)
-  double pose1_orientation = tf2::getYaw(pose1.orientation);
-  double pose2_orientation = tf2::getYaw(pose2.orientation);
-  unsigned int pose1_bin_id = NodeHybrid::motion_table.getClosestAngularBin(pose1_orientation);
-  unsigned int pose2_bin_id = NodeHybrid::motion_table.getClosestAngularBin(pose2_orientation);
-
-  // Check if they map to the same discrete planning state
-  return (static_cast<unsigned int>(std::round(pose1_mx)) == static_cast<unsigned int>(std::round(pose2_mx)) &&
-         (static_cast<unsigned int>(std::round(pose1_my)) == static_cast<unsigned int>(std::round(pose2_my)) &&
-         pose1_bin_id == pose2_bin_id));
-}
-
 void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t level)
 {
   std::lock_guard<std::mutex> lock_reinit(_mutex);
@@ -204,7 +182,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   costmap_2d::Costmap2D* costmap = _costmap;
 
   // Check if start and waypoint are the same in discrete planning space
-  bool same_discrete_state = arePosesSameDiscreteState(start.pose, waypoint.pose, costmap); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
+  bool same_discrete_state = NodeHybrid::arePosesSameDiscreteState(start.pose, waypoint.pose); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
   bool within_tolerance = tolerance > 0 && Utils::isSamePose(start.pose, waypoint.pose, tolerance);
 
   if (same_discrete_state || within_tolerance) {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -179,7 +179,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
 {
   // Check if start and waypoint are the same first
   if (Utils::isSamePose(start.pose, waypoint.pose, tolerance)) {
-    ROS_WARN_NAMED("smac_planner_hybrid", "Start and waypoint are the same, planning directly to goal");
+    ROS_WARN_NAMED("smac_planner_hybrid", "Start and waypoint are the same, skipping waypoint and planning from start to goal");
     if (!_search_info.allow_goal_overshoot) {
       _search_info.setSearchBound(goal_pose.pose);
       _search_info.setStart(start.pose.position);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -232,29 +232,32 @@ std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(cons
     return {};
   }
 
-  std::vector<geometry_msgs::PoseStamped> waypoints;
-
   const bool can_use_front_waypoint = !NodeHybrid::arePosesSameDiscreteState(waypoint_front.pose, start.pose, _costmap);
   const bool can_use_back_waypoint = !NodeHybrid::arePosesSameDiscreteState(waypoint_back.pose, start.pose, _costmap);
 
-  ROS_WARN_COND_NAMED(!can_use_back_waypoint, "smac_planner_hybrid", "front waypoint is same as start, will skip waypoint and plan to the goal");
-  ROS_WARN_COND_NAMED(!can_use_front_waypoint, "smac_planner_hybrid", "back_waypoint is same as start, will skip waypoint and plan to the goal");
+  // skip and plan directly to the goal, if any of the waypoint is same as the goal
+  if (!can_use_front_waypoint || !can_use_back_waypoint) {
+    ROS_WARN_NAMED("smac_planner_hybrid",
+                  "%s waypoint is same as start, will skip waypoint and plan to the goal",
+                  !can_use_back_waypoint ? "front" : "back");
+    return {};
+  }
 
+  // if allow goal overshoot: select any one from front or back
   if (!_search_info.allow_goal_overshoot) {
-    if (_search_info.isStartBehindSearchBounds() && can_use_back_waypoint) {
+    if (_search_info.isStartBehindSearchBounds()) {
       ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters back of the goal pose", _search_info.goal_align_distance);
-      waypoints.push_back(waypoint_back);
+      return {waypoint_back};
     }
-    if (can_use_front_waypoint) {
+    else {
       ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters front of the goal pose", _search_info.goal_align_distance);
-      waypoints.push_back(waypoint_front);
+      return {waypoint_front};
     }
   }
-  if (can_use_front_waypoint && can_use_back_waypoint) {
-      ROS_INFO_NAMED("smac_planner_hybrid", "found two waypoint, %f meters before and after the goal pose", _search_info.goal_align_distance);
-      waypoints = {waypoint_front, waypoint_back};
-  }
-  return waypoints;
+
+  // return both when allow goal overshoot is true and both are valid
+  ROS_INFO_NAMED("smac_planner_hybrid", "found two waypoint, %f meters before and after the goal pose", _search_info.goal_align_distance);
+  return {waypoint_front, waypoint_back};
 }
 
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -244,15 +244,15 @@ std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(cons
   if (!_search_info.allow_goal_overshoot) {
     if (_search_info.isStartBehindSearchBounds() && can_use_back_waypoint) {
       ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters back of the goal pose", _search_info.goal_align_distance);
-        waypoints.push_back(waypoint_back);
+      waypoints.push_back(waypoint_back);
     }
     else if (can_use_front_waypoint) {
-      ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is align %f meters front of the goal pose", _search_info.goal_align_distance);
-        waypoints.push_back(waypoint_front);
+      ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters front of the goal pose", _search_info.goal_align_distance);
+      waypoints.push_back(waypoint_front);
     }
   } else if (can_use_front_waypoint && can_use_back_waypoint){
     ROS_INFO_NAMED("smac_planner_hybrid", "found two waypoint, %f meters before and after the goal pose", _search_info.goal_align_distance);
-      waypoints = {waypoint_front, waypoint_back};
+    waypoints = {waypoint_front, waypoint_back};
   }
   return waypoints;
 }

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -225,19 +225,16 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
 }
 
 std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(const geometry_msgs::PoseStamped& start, const geometry_msgs::PoseStamped& goal, float tolerance) {
-
-  std::cout << "\n\n goal_align_distance : " << _search_info.goal_align_distance << "\n\n";
-  std::cout << "\n\n allow_goal_overshoot: " << _search_info.allow_goal_overshoot << "\n\n";
-  if (_search_info.goal_align_distance <= tolerance) {
-    return {};
-  }
-
   geometry_msgs::PoseStamped waypoint_front;
   geometry_msgs::PoseStamped waypoint_back;
   waypoint_front.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose, _search_info.goal_align_distance);
   waypoint_back.pose = Utils::getPoseAtDistanceAlongHeading(goal.pose,  -_search_info.goal_align_distance);
   waypoint_front.header = goal.header;
   waypoint_back.header = goal.header;
+
+  if (Utils::isSamePose(goal.pose, waypoint_front.pose, tolerance)) {
+    return {};
+  }
 
   std::vector<geometry_msgs::PoseStamped> waypoints;
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -24,6 +24,7 @@
 #include "mbf_msgs/GetPathResult.h"
 #include "nav_msgs/Path.h"
 #include "ros/console.h"
+#include "smac_planner/node_hybrid.hpp"
 #include "smac_planner/types.hpp"
 #include "smac_planner/utils.hpp"
 #include <base_local_planner/footprint_helper.h>
@@ -79,6 +80,28 @@ void SmacPlannerHybrid::initialize(
 
   dsrv_ = std::make_unique<dynamic_reconfigure::Server<SmacPlannerHybridConfig>>(private_nh);
   dsrv_->setCallback(boost::bind(&SmacPlannerHybrid::reconfigureCB, this, _1, _2));
+}
+
+bool SmacPlannerHybrid::arePosesSameDiscreteState(
+  const geometry_msgs::Pose& pose1,
+  const geometry_msgs::Pose& pose2,
+  costmap_2d::Costmap2D* costmap) const
+{
+  // Convert world coordinates to map coordinates
+  float pose1_mx, pose1_my, pose2_mx, pose2_my;
+  costmap->worldToMapContinuous(pose1.position.x, pose1.position.y, pose1_mx, pose1_my);
+  costmap->worldToMapContinuous(pose2.position.x, pose2.position.y, pose2_mx, pose2_my);
+
+  // Get orientation bins (using NodeHybrid's method)
+  double pose1_orientation = tf2::getYaw(pose1.orientation);
+  double pose2_orientation = tf2::getYaw(pose2.orientation);
+  unsigned int pose1_bin_id = NodeHybrid::motion_table.getClosestAngularBin(pose1_orientation);
+  unsigned int pose2_bin_id = NodeHybrid::motion_table.getClosestAngularBin(pose2_orientation);
+
+  // Check if they map to the same discrete planning state
+  return (static_cast<unsigned int>(std::round(pose1_mx)) == static_cast<unsigned int>(std::round(pose2_mx)) &&
+         (static_cast<unsigned int>(std::round(pose1_my)) == static_cast<unsigned int>(std::round(pose2_my)) &&
+         pose1_bin_id == pose2_bin_id));
 }
 
 void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t level)
@@ -177,9 +200,18 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   const geometry_msgs::PoseStamped& goal_pose,
   const double& tolerance)
 {
-  // Check if start and waypoint are the same first
-  if (Utils::isSamePose(start.pose, waypoint.pose, tolerance)) {
-    ROS_WARN_NAMED("smac_planner_hybrid", "Start and waypoint are the same, planning directly to goal");
+  // Get the costmap (downsampled if needed)
+  costmap_2d::Costmap2D* costmap = _costmap;
+  if (_costmap_downsampler) {
+    costmap = _costmap_downsampler->downsample(_config.downsampling_factor);
+  }
+  // Check if start and waypoint are the same in discrete planning space
+  bool same_discrete_state = arePosesSameDiscreteState(start.pose, waypoint.pose, costmap); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
+  bool within_tolerance = tolerance > 0 && Utils::isSamePose(start.pose, waypoint.pose, tolerance);
+
+  if (same_discrete_state || within_tolerance) {
+    ROS_WARN_NAMED("smac_planner_hybrid",
+      "Start and waypoint map to same discrete state, skipping waypoint and planning from start to goal");
     if (!_search_info.allow_goal_overshoot) {
       _search_info.setSearchBound(goal_pose.pose);
       _search_info.setStart(start.pose.position);
@@ -190,7 +222,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
     return result;
   }
 
-  // Normal case: start and waypoint are different
+  // Normal case: start and waypoint are different in discrete space
   if (!_search_info.allow_goal_overshoot) {
     _search_info.setSearchBound(goal_pose.pose);
     _search_info.setStart(waypoint.pose.position);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -238,8 +238,8 @@ std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(cons
   const bool can_use_front_waypoint = !NodeHybrid::arePosesSameDiscreteState(waypoint_front.pose, start.pose, _costmap);
   const bool can_use_back_waypoint = !NodeHybrid::arePosesSameDiscreteState(waypoint_back.pose, start.pose, _costmap);
 
-  ROS_WARN_COND_NAMED(!can_use_back_waypoint, "smac_planner_hybrid", "front waypoint same as start");
-  ROS_WARN_COND_NAMED(!can_use_front_waypoint, "smac_planner_hybrid", "back_waypoint is same as start");
+  ROS_WARN_COND_NAMED(!can_use_back_waypoint, "smac_planner_hybrid", "front waypoint is same as start, will skip waypoint and plan to the goal");
+  ROS_WARN_COND_NAMED(!can_use_front_waypoint, "smac_planner_hybrid", "back_waypoint is same as start, will skip waypoint and plan to the goal");
 
   if (!_search_info.allow_goal_overshoot) {
     if (_search_info.isStartBehindSearchBounds() && can_use_back_waypoint) {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -180,9 +180,6 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   const geometry_msgs::PoseStamped& goal_pose,
   const double& tolerance)
 {
-  // Get the costmap (downsampled if needed)
-  costmap_2d::Costmap2D* costmap = _costmap;
-
   if (!_search_info.allow_goal_overshoot) {
     _search_info.setSearchBound(goal_pose.pose);
     _search_info.setStart(waypoint.pose.position);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -180,7 +180,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   const geometry_msgs::PoseStamped& goal_pose,
   const double& tolerance)
 {
-  if (!_search_info.allow_goal_overshoot){
+  if (!_search_info.allow_goal_overshoot) {
   _search_info.setSearchBound(goal_pose.pose);
   _search_info.setStart(waypoint.pose.position);
   _a_star->setSearchBounds(goal_pose.pose, waypoint.pose.position,  _search_info.allow_goal_overshoot);
@@ -202,7 +202,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
 
   // if the robot is not between the goal and the waypoint, then we set the search bounds to the waypoint.
   const bool is_robot_between_goal_and_waypoint = Utils::isBetweenPoints(start.pose, waypoint.pose, goal_pose.pose);
-  if (!is_robot_between_goal_and_waypoint){
+  if (!is_robot_between_goal_and_waypoint) {
     _search_info.setSearchBound(waypoint.pose);
     _search_info.setStart(start.pose.position);
     _a_star->setSearchBounds(waypoint.pose, start.pose.position,  _search_info.allow_goal_overshoot);
@@ -250,9 +250,9 @@ std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(cons
       ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters front of the goal pose", _search_info.goal_align_distance);
       waypoints.push_back(waypoint_front);
     }
-  } else if (can_use_front_waypoint && can_use_back_waypoint){
-    ROS_INFO_NAMED("smac_planner_hybrid", "found two waypoint, %f meters before and after the goal pose", _search_info.goal_align_distance);
-    waypoints = {waypoint_front, waypoint_back};
+  } else if (can_use_front_waypoint && can_use_back_waypoint) {
+      ROS_INFO_NAMED("smac_planner_hybrid", "found two waypoint, %f meters before and after the goal pose", _search_info.goal_align_distance);
+      waypoints = {waypoint_front, waypoint_back};
   }
   return waypoints;
 }
@@ -277,7 +277,7 @@ uint32_t SmacPlannerHybrid::makePlan(
 
 
   // check if the start is already under tolerance within the goal
-  if (Utils::isSamePose(start.pose, goal.pose, tolerance)){
+  if (Utils::isSamePose(start.pose, goal.pose, tolerance)) {
     ROS_INFO_NAMED("smac_planner_hybrid", "Start and goal same or goal under tolerance");
     plan = {};
     return mbf_msgs::GetPathResult::SUCCESS;
@@ -403,7 +403,7 @@ void SmacPlannerHybrid::collision(const geometry_msgs::Pose& robot_pose, const r
     }
   }
 
-  if (colliding_cells.empty()){
+  if (colliding_cells.empty()) {
     ROS_DEBUG_STREAM_NAMED("smac_planner_hybrid","no collision cells found at robot pose" << robot_pose);
     return;
   }

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -183,23 +183,6 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   // Get the costmap (downsampled if needed)
   costmap_2d::Costmap2D* costmap = _costmap;
 
-  // Check if start and waypoint are the same in discrete planning space
-  // bool same_discrete_state = NodeHybrid::arePosesSameDiscreteState(start.pose, waypoint.pose, costmap); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
-  // bool within_tolerance = tolerance > 0 && Utils::isSamePose(start.pose, waypoint.pose, tolerance);
-
-  // if (same_discrete_state || within_tolerance) {
-  //   ROS_WARN_NAMED("smac_planner_hybrid",
-  //     "Start and waypoint map to same discrete state, skipping waypoint and planning from start to goal");
-  //   if (!_search_info.allow_goal_overshoot) {
-  //     _search_info.setSearchBound(goal_pose.pose);
-  //     _search_info.setStart(start.pose.position);
-  //     _a_star->setSearchBounds(goal_pose.pose, start.pose.position, _search_info.allow_goal_overshoot);
-  //   }
-  //   PlanResult result;
-  //   getPath(start, goal_pose, tolerance, result);
-  //   return result;
-  // }
-
   if (!_search_info.allow_goal_overshoot) {
     _search_info.setSearchBound(goal_pose.pose);
     _search_info.setStart(waypoint.pose.position);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -171,16 +171,82 @@ void SmacPlannerHybrid::reconfigureCB(SmacPlannerHybridConfig& config, uint32_t 
     _config.tolerance, toString(_motion_model).c_str());
 }
 
+// PlanResult SmacPlannerHybrid::planWithWaypoint(
+//   const geometry_msgs::PoseStamped& start,
+//   const geometry_msgs::PoseStamped& waypoint,
+//   const geometry_msgs::PoseStamped& goal_pose,
+//   const double& tolerance)
+// {
+//   if (!_search_info.allow_goal_overshoot){
+//   _search_info.setSearchBound(goal_pose.pose);
+//   _search_info.setStart(waypoint.pose.position);
+//   _a_star->setSearchBounds(goal_pose.pose, waypoint.pose.position,  _search_info.allow_goal_overshoot);
+//   }
+
+//   PlanResult segment2;
+//   if (Utils::isSamePose(start.pose, waypoint.pose, tolerance)){
+//     getPath(start, goal_pose, tolerance, segment2);
+//     return segment2;
+//   }
+
+//   // waypoint to goal pose
+//   getPath(waypoint, goal_pose, tolerance, segment2);
+//   if (!segment2.isValid())
+//   {
+//     // the segment is from waypoint to goal pose, so blocked start means blocked waypoint.
+//     if (segment2.result_code == mbf_msgs::GetPathResult::BLOCKED_START) {
+//       segment2.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
+//       ROS_ERROR_NAMED("smac_planner_hybrid", "waypoint pose is blocked");
+//       segment2.message = "Waypoint pose is blocked";
+//     }
+//     return segment2;
+//   }
+
+//   // if the robot is not between the goal and the waypoint, then we set the search bounds to the waypoint.
+//   const bool is_robot_between_goal_and_waypoint = Utils::isBetweenPoints(start.pose, waypoint.pose, goal_pose.pose);
+//   if (!is_robot_between_goal_and_waypoint){
+//     _search_info.setSearchBound(waypoint.pose);
+//     _search_info.setStart(start.pose.position);
+//     _a_star->setSearchBounds(waypoint.pose, start.pose.position,  _search_info.allow_goal_overshoot);
+//   }
+
+//   // robot_pose to waypoint
+//   PlanResult segment1;
+//   getPath(start, waypoint, tolerance, segment1);
+
+//   if (!segment1.isValid())
+//   {
+//     return segment1;
+//   }
+
+//   const PlanResult result = segment1 + segment2;
+//   return result;
+// }
+
 PlanResult SmacPlannerHybrid::planWithWaypoint(
   const geometry_msgs::PoseStamped& start,
   const geometry_msgs::PoseStamped& waypoint,
   const geometry_msgs::PoseStamped& goal_pose,
   const double& tolerance)
 {
-  if (!_search_info.allow_goal_overshoot){
-  _search_info.setSearchBound(goal_pose.pose);
-  _search_info.setStart(waypoint.pose.position);
-  _a_star->setSearchBounds(goal_pose.pose, waypoint.pose.position,  _search_info.allow_goal_overshoot);
+  // Check if start and waypoint are the same first
+  if (Utils::isSamePose(start.pose, waypoint.pose, tolerance)) {
+    ROS_WARN_NAMED("smac_planner_hybrid", "Start and waypoint are the same, planning directly to goal");
+    if (!_search_info.allow_goal_overshoot) {
+      _search_info.setSearchBound(goal_pose.pose);
+      _search_info.setStart(start.pose.position);
+      _a_star->setSearchBounds(goal_pose.pose, start.pose.position, _search_info.allow_goal_overshoot);
+    }
+    PlanResult result;
+    getPath(start, goal_pose, tolerance, result);
+    return result;
+  }
+
+  // Normal case: start and waypoint are different
+  if (!_search_info.allow_goal_overshoot) {
+    _search_info.setSearchBound(goal_pose.pose);
+    _search_info.setStart(waypoint.pose.position);
+    _a_star->setSearchBounds(goal_pose.pose, waypoint.pose.position,  _search_info.allow_goal_overshoot);
   }
 
   // waypoint to goal pose

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -245,11 +245,12 @@ std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(cons
       ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters back of the goal pose", _search_info.goal_align_distance);
       waypoints.push_back(waypoint_back);
     }
-    else if (can_use_front_waypoint) {
+    if (can_use_front_waypoint) {
       ROS_INFO_NAMED("smac_planner_hybrid", "waypoint is %f meters front of the goal pose", _search_info.goal_align_distance);
       waypoints.push_back(waypoint_front);
     }
-  } else if (can_use_front_waypoint && can_use_back_waypoint) {
+  }
+  if (can_use_front_waypoint && can_use_back_waypoint) {
       ROS_INFO_NAMED("smac_planner_hybrid", "found two waypoint, %f meters before and after the goal pose", _search_info.goal_align_distance);
       waypoints = {waypoint_front, waypoint_back};
   }

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -179,7 +179,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
 {
   // Check if start and waypoint are the same first
   if (Utils::isSamePose(start.pose, waypoint.pose, tolerance)) {
-    ROS_WARN_NAMED("smac_planner_hybrid", "Start and waypoint are the same, skipping waypoint and planning from start to goal");
+    ROS_WARN_NAMED("smac_planner_hybrid", "Start and waypoint are the same, planning directly to goal");
     if (!_search_info.allow_goal_overshoot) {
       _search_info.setSearchBound(goal_pose.pose);
       _search_info.setStart(start.pose.position);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -182,7 +182,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   costmap_2d::Costmap2D* costmap = _costmap;
 
   // Check if start and waypoint are the same in discrete planning space
-  bool same_discrete_state = NodeHybrid::arePosesSameDiscreteState(start.pose, waypoint.pose); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
+  bool same_discrete_state = NodeHybrid::arePosesSameDiscreteState(start.pose, waypoint.pose, costmap); // equivalent to *_a_star->getStart() == *_a_star->getGoal()
   bool within_tolerance = tolerance > 0 && Utils::isSamePose(start.pose, waypoint.pose, tolerance);
 
   if (same_discrete_state || within_tolerance) {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -235,7 +235,7 @@ std::vector<geometry_msgs::PoseStamped> SmacPlannerHybrid::computeWaypoints(cons
   const bool can_use_front_waypoint = !NodeHybrid::arePosesSameDiscreteState(waypoint_front.pose, start.pose, _costmap);
   const bool can_use_back_waypoint = !NodeHybrid::arePosesSameDiscreteState(waypoint_back.pose, start.pose, _costmap);
 
-  // skip and plan directly to the goal, if any of the waypoint is same as the goal
+  // skip and plan directly to the goal, if any of the waypoint is same as the start
   if (!can_use_front_waypoint || !can_use_back_waypoint) {
     ROS_WARN_NAMED("smac_planner_hybrid",
                   "%s waypoint is same as start, will skip waypoint and plan to the goal",

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -180,10 +180,10 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   const geometry_msgs::PoseStamped& goal_pose,
   const double& tolerance)
 {
-  if (!_search_info.allow_goal_overshoot) {
-    _search_info.setSearchBound(goal_pose.pose);
-    _search_info.setStart(waypoint.pose.position);
-    _a_star->setSearchBounds(goal_pose.pose, waypoint.pose.position,  _search_info.allow_goal_overshoot);
+  if (!_search_info.allow_goal_overshoot){
+  _search_info.setSearchBound(goal_pose.pose);
+  _search_info.setStart(waypoint.pose.position);
+  _a_star->setSearchBounds(goal_pose.pose, waypoint.pose.position,  _search_info.allow_goal_overshoot);
   }
 
   // waypoint to goal pose

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -21,7 +21,6 @@
 #include <boost/scope_exit.hpp>
 
 #include "costmap_2d/costmap_2d_ros.h"
-#include "geometry_msgs/Pose.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "mbf_msgs/GetPathResult.h"
 #include "nav_msgs/Path.h"


### PR DESCRIPTION
[AB#78998](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/78998)
It used to fail when start pose and waypoint pose was same (in discrete states). Now it will skip waypoint in this case and give a warning.

After fix:
<img width="1927" height="1386" alt="image" src="https://github.com/user-attachments/assets/7439182d-b937-445c-82ad-9375e07d447d" />


Before fix:
<img width="1996" height="1404" alt="image" src="https://github.com/user-attachments/assets/4e0f8662-5efa-4bc8-88ee-1f4e97edb2ba" />
