### PR TITLE
feat: search straight path from waypoint to goal

### DIFF
--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -24,7 +24,6 @@
 
 #include "costmap_2d/costmap_2d.h"
 
-#include "geometry_msgs/Point.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "smac_planner/thirdparty/robin_hood.h"
 #include "smac_planner/analytic_expansion.hpp"
@@ -127,15 +126,15 @@ public:
   void setSearchBounds(const geometry_msgs::Pose& search_bounds, const geometry_msgs::Point& start_point, bool allow_goal_overshoot);
 
   void setSearchSpace(const Rectangle& space);
-  /**
-   * @brief Set the goal for planning, as a node index
-   * @param mx The node X index of the goal
-   * @param my The node Y index of the goal
-   * @param dim_3 The node dim_3 index of the goal
-   */
 
   void removeSearchSpace();
 
+  /**
+  * @brief Set the goal for planning, as a node index
+  * @param mx The node X index of the goal
+  * @param my The node Y index of the goal
+  * @param dim_3 The node dim_3 index of the goal
+  */
   void setGoal(
     const float & mx,
     const float & my,

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -130,11 +130,11 @@ public:
   void removeSearchSpace();
 
   /**
-  * @brief Set the goal for planning, as a node index
-  * @param mx The node X index of the goal
-  * @param my The node Y index of the goal
-  * @param dim_3 The node dim_3 index of the goal
-  */
+   * @brief Set the goal for planning, as a node index
+   * @param mx The node X index of the goal
+   * @param my The node Y index of the goal
+   * @param dim_3 The node dim_3 index of the goal
+   */
   void setGoal(
     const float & mx,
     const float & my,

--- a/include/smac_planner/a_star.hpp
+++ b/include/smac_planner/a_star.hpp
@@ -24,6 +24,7 @@
 
 #include "costmap_2d/costmap_2d.h"
 
+#include "geometry_msgs/Point.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "smac_planner/thirdparty/robin_hood.h"
 #include "smac_planner/analytic_expansion.hpp"
@@ -125,12 +126,16 @@ public:
    */
   void setSearchBounds(const geometry_msgs::Pose& search_bounds, const geometry_msgs::Point& start_point, bool allow_goal_overshoot);
 
+  void setSearchSpace(const Rectangle& space);
   /**
    * @brief Set the goal for planning, as a node index
    * @param mx The node X index of the goal
    * @param my The node Y index of the goal
    * @param dim_3 The node dim_3 index of the goal
    */
+
+  void removeSearchSpace();
+
   void setGoal(
     const float & mx,
     const float & my,
@@ -259,6 +264,9 @@ protected:
    * @param pose the pose relative to which we want to check the position of the node
    */
   bool isBehindPose(const NodePtr& node, const geometry_msgs::Pose& pose);
+
+
+  bool isInsideSearchSpace(const NodePtr& node, const Rectangle& search_space);
 
     /**
    * @brief Clear Start

--- a/include/smac_planner/smac_planner_hybrid.hpp
+++ b/include/smac_planner/smac_planner_hybrid.hpp
@@ -148,12 +148,14 @@ protected:
   SearchInfo _search_info;
   bool _planning_canceled;
   MotionModel _motion_model;
+  std::optional<Rectangle> _search_space ;
   ros::Publisher _raw_plan_publisher;
   ros::Publisher _final_plan_publisher;
   ros::Publisher _planned_footprints_publisher;
   ros::Publisher _expansions_publisher;
   ros::Publisher _waypoint_publisher;
   ros::Publisher _collision_pub;
+  ros::Publisher _search_space_publisher;
   std::mutex _mutex;
 
   std::vector<geometry_msgs::PoseStamped> computeWaypoints(const geometry_msgs::PoseStamped& start, const geometry_msgs::PoseStamped& goal, float tolerance);

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -28,17 +28,22 @@ namespace smac_planner
 
 typedef std::pair<float, unsigned int> NodeHeuristicPair;
 
+
 struct Rectangle {
   Rectangle() = default;
-  Rectangle(geometry_msgs::Point diagonal_corner_1, geometry_msgs::Point diagonal_corner_2);
+  Rectangle(geometry_msgs::Point diagonal_corner_1, geometry_msgs::Point diagonal_corner_2, double width);
 
   bool pointInside(const geometry_msgs::Point& point) const;
 
-  private:
-    geometry_msgs::Point diagonal_corner_1;
-    geometry_msgs::Point diagonal_corner_2;
-    double _max_x, _max_y, _min_x, _min_y;
+private:
+  geometry_msgs::Point _corner1, _corner2;
+  double _width;
+  // void visualize();
+  // get_corners();
+  geometry_msgs::Point _dir;    // unit direction vector from corner1 to corner2
+  double _length;               // total length from corner1 to corner2
 };
+
 
 /**
  * @struct smac_planner::SearchInfo

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -33,7 +33,7 @@ typedef std::pair<float, unsigned int> NodeHeuristicPair;
 
 struct Rectangle {
   Rectangle() = default;
-  Rectangle(geometry_msgs::Point diagonal_corner_1, geometry_msgs::Point diagonal_corner_2, double width);
+  Rectangle(const geometry_msgs::Point& diagonal_corner_1, const geometry_msgs::Point& diagonal_corner_2, const double width);
   bool pointInside(const geometry_msgs::Point& point) const;
   std::vector<geometry_msgs::Point> getCorners() const;
 

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -20,10 +20,6 @@
 #include <string>
 #include <geometry_msgs/PoseStamped.h>
 #include <optional>
-#include "geometry_msgs/Point.h"
-#include "geometry_msgs/Pose.h"
-#include "ros/node_handle.h"
-#include "visualization_msgs/Marker.h"
 #include <mbf_msgs/GetPathResult.h>
 namespace smac_planner
 {

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -74,13 +74,12 @@ struct SearchInfo
   geometry_msgs::Pose getSearchBound();
   void setSearchBound(const geometry_msgs::Pose& search_bound);
   void setSearchSpace(const Rectangle& space);
-  std::optional<Rectangle> getSearchSpace();
-  bool isSearchSpaceSet();
+  std::optional<Rectangle> getSearchSpace() const;
+  bool isSearchSpaceSet() const;
   void removeSearchSpace();
   bool isStartBehindSearchBounds();
 
 private:
-  // smac_planner::Rectangle search_space;
   geometry_msgs::Point _start_pose;
   geometry_msgs::Pose _search_bound;
   std::optional<bool> is_start_behind_goal;

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -20,11 +20,25 @@
 #include <string>
 #include <geometry_msgs/PoseStamped.h>
 #include <optional>
+#include "geometry_msgs/Point.h"
+#include "geometry_msgs/Pose.h"
 #include <mbf_msgs/GetPathResult.h>
 namespace smac_planner
 {
 
 typedef std::pair<float, unsigned int> NodeHeuristicPair;
+
+struct Rectangle {
+  Rectangle() = default;
+  Rectangle(geometry_msgs::Point diagonal_corner_1, geometry_msgs::Point diagonal_corner_2);
+
+  bool pointInside(const geometry_msgs::Point& point) const;
+
+  private:
+    geometry_msgs::Point diagonal_corner_1;
+    geometry_msgs::Point diagonal_corner_2;
+    double _max_x, _max_y, _min_x, _min_y;
+};
 
 /**
  * @struct smac_planner::SearchInfo
@@ -54,12 +68,18 @@ struct SearchInfo
   void setStart(const geometry_msgs::Point& start);
   geometry_msgs::Pose getSearchBound();
   void setSearchBound(const geometry_msgs::Pose& search_bound);
+  void setSearchSpace(const Rectangle& space);
+  std::optional<Rectangle> getSearchSpace();
+  bool isSearchSpaceSet();
+  void removeSearchSpace();
   bool isStartBehindSearchBounds();
 
 private:
+  // smac_planner::Rectangle search_space;
   geometry_msgs::Point _start_pose;
   geometry_msgs::Pose _search_bound;
   std::optional<bool> is_start_behind_goal;
+  std::optional<Rectangle> _search_space;
 };
 
 struct PlanResult {

--- a/include/smac_planner/types.hpp
+++ b/include/smac_planner/types.hpp
@@ -22,6 +22,8 @@
 #include <optional>
 #include "geometry_msgs/Point.h"
 #include "geometry_msgs/Pose.h"
+#include "ros/node_handle.h"
+#include "visualization_msgs/Marker.h"
 #include <mbf_msgs/GetPathResult.h>
 namespace smac_planner
 {
@@ -32,14 +34,12 @@ typedef std::pair<float, unsigned int> NodeHeuristicPair;
 struct Rectangle {
   Rectangle() = default;
   Rectangle(geometry_msgs::Point diagonal_corner_1, geometry_msgs::Point diagonal_corner_2, double width);
-
   bool pointInside(const geometry_msgs::Point& point) const;
+  std::vector<geometry_msgs::Point> getCorners() const;
 
 private:
   geometry_msgs::Point _corner1, _corner2;
   double _width;
-  // void visualize();
-  // get_corners();
   geometry_msgs::Point _dir;    // unit direction vector from corner1 to corner2
   double _length;               // total length from corner1 to corner2
 };

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -171,6 +171,45 @@ public:
     return output_pose;
   }
 
+  static bool isPathStraight(const std::vector<geometry_msgs::PoseStamped>& path, double width_threshold = 0.1)
+  {
+      if (path.size() < 3) {
+          return true;
+      }
+
+      // Create a line from start to end point
+      const auto& start = path.front().pose.position;
+      const auto& end = path.back().pose.position;
+
+      // Calculate the line equation: ax + by + c = 0
+      double a = end.y - start.y;
+      double b = start.x - end.x;
+      double c = end.x * start.y - start.x * end.y;
+
+      // Normalize the line equation coefficients
+      double norm = std::sqrt(a * a + b * b);
+      if (norm < 1e-6) {
+          return true; // Start and end are the same point
+      }
+      a /= norm;
+      b /= norm;
+      c /= norm;
+
+      // Check if all points are within the width threshold from the line
+      for (const auto& pose_stamped : path) {
+          const auto& point = pose_stamped.pose.position;
+
+          // Calculate perpendicular distance from point to line
+          double distance = std::abs(a * point.x + b * point.y + c);
+
+          if (distance > width_threshold / 2.0) { // Half width since we check both sides
+              return false;
+          }
+      }
+
+      return true;
+  }
+
   static bool hasCuspPoint(const std::vector<geometry_msgs::PoseStamped>& path)
   {
     if (path.size() < 3) {

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -209,15 +209,8 @@ public:
     double length = std::max(0.01, sqrt(dx * dx + dy * dy));
 
     // Normalize the direction vector
-    if (length > 0) {
-        dx /= length;
-        dy /= length;
-    } else {
-        // If start and goal are the same point, use arbitrary direction
-        dx = 1.0;
-        dy = 0.0;
-        length = 1.0; // minimum length
-    }
+    dx /= length;
+    dy /= length;
 
     const double front_padding = 1.0; // padding in front of goal
     const double back_padding = 0.2;  // padding behind start

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -245,51 +245,6 @@ public:
     return Rectangle(diagonal1, diagonal2);
   }
 
-  // /**
-  // * @brief check if the path fits in a width_threshold wide aisle if it fits then it is considered straight
-  // * @param path vector of geometry_msgs::PoseStamped
-  // * @param width_thresold allowed deviation in meters (default is 0.1)
-  // * @return bool
-  // */
-  // static bool isPathStraight(const std::vector<geometry_msgs::PoseStamped>& path, double width_threshold = 0.1)
-  // {
-  //     if (path.size() < 3) {
-  //         return true;
-  //     }
-
-  //     // Create a line from start to end point
-  //     const auto& start = path.front().pose.position;
-  //     const auto& end = path.back().pose.position;
-
-  //     // Calculate the line equation: ax + by + c = 0
-  //     double a = end.y - start.y;
-  //     double b = start.x - end.x;
-  //     double c = end.x * start.y - start.x * end.y;
-
-  //     // Normalize the line equation coefficients
-  //     double norm = std::sqrt(a * a + b * b);
-  //     if (norm < 1e-6) {
-  //         return true; // Start and end are the same point
-  //     }
-  //     a /= norm;
-  //     b /= norm;
-  //     c /= norm;
-
-  //     // Check if all points are within the width threshold from the line
-  //     for (const auto& pose_stamped : path) {
-  //         const auto& point = pose_stamped.pose.position;
-
-  //         // Calculate perpendicular distance from point to line
-  //         double distance = std::abs(a * point.x + b * point.y + c);
-
-  //         if (distance > width_threshold / 2.0) { // Half width since we check both sides
-  //             return false;
-  //         }
-  //     }
-
-  //     return true;
-  // }
-
 
   /**
   * Computes the length of given path, where the path is a vector of geometry_msgs::PoseStamped and the length is

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -171,6 +171,13 @@ public:
     return output_pose;
   }
 
+
+  /**
+  * @brief check if the path fits in a width_threshold wide aisle if it fits then it is considered straight
+  * @param path vector of geometry_msgs::PoseStamped
+  * @param width_thresold allowed deviation in meters (default is 0.1)
+  * @return bool
+  */
   static bool isPathStraight(const std::vector<geometry_msgs::PoseStamped>& path, double width_threshold = 0.1)
   {
       if (path.size() < 3) {
@@ -210,43 +217,6 @@ public:
       return true;
   }
 
-  static bool hasCuspPoint(const std::vector<geometry_msgs::PoseStamped>& path)
-  {
-    if (path.size() < 3) {
-      return false;
-    }
-
-    auto computeHeading = [](const geometry_msgs::PoseStamped& from,
-                            const geometry_msgs::PoseStamped& to) {
-      double dx = to.pose.position.x - from.pose.position.x;
-      double dy = to.pose.position.y - from.pose.position.y;
-      return (dx == 0.0 && dy == 0.0) ? NAN
-                                      : std::atan2(dy, dx);
-    };
-
-    auto angleDiff = [](double a, double b) {
-      double diff = a - b;
-      while (diff > M_PI) diff -= 2.0 * M_PI; // normalize
-      while (diff < -M_PI) diff += 2.0 * M_PI; // normalize
-      return diff;
-    };
-
-    for (size_t i = 1; i < path.size() - 1; ++i) {
-      double prev_heading = computeHeading(path[i-1], path[i]);
-      double curr_heading = computeHeading(path[i], path[i+1]);
-
-      if (std::isnan(prev_heading) || std::isnan(curr_heading)) {
-        continue;
-      }
-
-      double heading_diff = std::abs(angleDiff(curr_heading, prev_heading));
-      if (heading_diff > M_PI_2) {
-        return true;
-      }
-    }
-
-    return false;
-  }
 
   /**
   * Computes the length of given path, where the path is a vector of geometry_msgs::PoseStamped and the length is

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -25,7 +25,6 @@
 #include "nlohmann/json.hpp"
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Pose.h"
-#include "ros/node_handle.h"
 #include "tf2/utils.h"
 #include "costmap_2d/costmap_2d_ros.h"
 #include "costmap_2d/inflation_layer.h"

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -245,50 +245,50 @@ public:
     return Rectangle(diagonal1, diagonal2);
   }
 
-  /**
-  * @brief check if the path fits in a width_threshold wide aisle if it fits then it is considered straight
-  * @param path vector of geometry_msgs::PoseStamped
-  * @param width_thresold allowed deviation in meters (default is 0.1)
-  * @return bool
-  */
-  static bool isPathStraight(const std::vector<geometry_msgs::PoseStamped>& path, double width_threshold = 0.1)
-  {
-      if (path.size() < 3) {
-          return true;
-      }
+  // /**
+  // * @brief check if the path fits in a width_threshold wide aisle if it fits then it is considered straight
+  // * @param path vector of geometry_msgs::PoseStamped
+  // * @param width_thresold allowed deviation in meters (default is 0.1)
+  // * @return bool
+  // */
+  // static bool isPathStraight(const std::vector<geometry_msgs::PoseStamped>& path, double width_threshold = 0.1)
+  // {
+  //     if (path.size() < 3) {
+  //         return true;
+  //     }
 
-      // Create a line from start to end point
-      const auto& start = path.front().pose.position;
-      const auto& end = path.back().pose.position;
+  //     // Create a line from start to end point
+  //     const auto& start = path.front().pose.position;
+  //     const auto& end = path.back().pose.position;
 
-      // Calculate the line equation: ax + by + c = 0
-      double a = end.y - start.y;
-      double b = start.x - end.x;
-      double c = end.x * start.y - start.x * end.y;
+  //     // Calculate the line equation: ax + by + c = 0
+  //     double a = end.y - start.y;
+  //     double b = start.x - end.x;
+  //     double c = end.x * start.y - start.x * end.y;
 
-      // Normalize the line equation coefficients
-      double norm = std::sqrt(a * a + b * b);
-      if (norm < 1e-6) {
-          return true; // Start and end are the same point
-      }
-      a /= norm;
-      b /= norm;
-      c /= norm;
+  //     // Normalize the line equation coefficients
+  //     double norm = std::sqrt(a * a + b * b);
+  //     if (norm < 1e-6) {
+  //         return true; // Start and end are the same point
+  //     }
+  //     a /= norm;
+  //     b /= norm;
+  //     c /= norm;
 
-      // Check if all points are within the width threshold from the line
-      for (const auto& pose_stamped : path) {
-          const auto& point = pose_stamped.pose.position;
+  //     // Check if all points are within the width threshold from the line
+  //     for (const auto& pose_stamped : path) {
+  //         const auto& point = pose_stamped.pose.position;
 
-          // Calculate perpendicular distance from point to line
-          double distance = std::abs(a * point.x + b * point.y + c);
+  //         // Calculate perpendicular distance from point to line
+  //         double distance = std::abs(a * point.x + b * point.y + c);
 
-          if (distance > width_threshold / 2.0) { // Half width since we check both sides
-              return false;
-          }
-      }
+  //         if (distance > width_threshold / 2.0) { // Half width since we check both sides
+  //             return false;
+  //         }
+  //     }
 
-      return true;
-  }
+  //     return true;
+  // }
 
 
   /**

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -25,6 +25,7 @@
 #include "nlohmann/json.hpp"
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Pose.h"
+#include "ros/console.h"
 #include "tf2/utils.h"
 #include "costmap_2d/costmap_2d_ros.h"
 #include "costmap_2d/inflation_layer.h"
@@ -187,8 +188,8 @@ public:
 
     auto angleDiff = [](double a, double b) {
       double diff = a - b;
-      while (diff > M_PI) diff -= 2.0 * M_PI;
-      while (diff < -M_PI) diff += 2.0 * M_PI;
+      while (diff > M_PI) diff -= 2.0 * M_PI; // normalize
+      while (diff < -M_PI) diff += 2.0 * M_PI; // normalize
       return diff;
     };
 
@@ -202,10 +203,6 @@ public:
 
       double heading_diff = std::abs(angleDiff(curr_heading, prev_heading));
       if (heading_diff > M_PI_2) {
-        ROS_INFO("Found cusp point at (%f, %f), heading diff: %f",
-                path[i].pose.position.x,
-                path[i].pose.position.y,
-                heading_diff);
         return true;
       }
     }

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -25,7 +25,6 @@
 #include "nlohmann/json.hpp"
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Pose.h"
-#include "ros/console.h"
 #include "tf2/utils.h"
 #include "costmap_2d/costmap_2d_ros.h"
 #include "costmap_2d/inflation_layer.h"

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -133,7 +133,7 @@ public:
     rectangle_marker.id = id;
     rectangle_marker.type = visualization_msgs::Marker::LINE_STRIP;
     rectangle_marker.action = visualization_msgs::Marker::ADD;
-    rectangle_marker.scale.x = 0.05;
+    rectangle_marker.scale.x = 0.01;
 
     rectangle_marker.color.r = 0.0f;
     rectangle_marker.color.g = 1.0f;
@@ -206,7 +206,7 @@ public:
     double dy = goal.y - start.y;
 
     // Calculate the length of the line segment
-    double length = sqrt(dx * dx + dy * dy);
+    double length = std::max(0.01, sqrt(dx * dx + dy * dy));
 
     // Normalize the direction vector
     if (length > 0) {
@@ -220,7 +220,7 @@ public:
     }
 
     const double front_padding = 1.0; // padding in front of goal
-    const double back_padding = 1.0;  // padding behind start
+    const double back_padding = 0.2;  // padding behind start
 
     geometry_msgs::Point diagonal_corner_1, diagonal_corner_2;
 

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -191,24 +191,19 @@ public:
         length = 1.0; // minimum length
     }
 
-    // Calculate perpendicular vector (rotated 90 degrees counterclockwise)
-    double perp_dx = -dy;
-    double perp_dy = dx;
-
     const double front_padding = 2.0; // padding in front of goal
     const double back_padding = 2.0;  // padding behind start
 
     geometry_msgs::Point diagonal_corner_1, diagonal_corner_2;
 
-    // Start with the perpendicular offset for width
-    double half_width = width / 2.0;
+    const double half_width = width / 2.0;
 
     // Corner behind start (negative direction along the line)
-    diagonal_corner_1.x = start.x - back_padding * dx + half_width * perp_dx;
-    diagonal_corner_1.y = start.y - back_padding * dy + half_width * perp_dy;
+    diagonal_corner_1.x = start.x - back_padding * dx - half_width * dy;
+    diagonal_corner_1.y = start.y - back_padding * dy + half_width * dx;
 
-    diagonal_corner_2.x = goal.x + front_padding * dx - half_width * perp_dx;
-    diagonal_corner_2.y = goal.y + front_padding * dy - half_width * perp_dy;
+    diagonal_corner_2.x = goal.x + front_padding * dx + half_width * dy;
+    diagonal_corner_2.y = goal.y + front_padding * dy - half_width * dx;
 
     return Rectangle(diagonal_corner_1, diagonal_corner_2, width);
   }

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -195,54 +195,22 @@ public:
     double perp_dx = -dy;
     double perp_dy = dx;
 
-    // Define padding (you can adjust these values as needed)
     const double front_padding = 2.0; // padding in front of goal
     const double back_padding = 2.0;  // padding behind start
 
-    // Calculate the four corners of the rectangle
-    geometry_msgs::Point corner1, corner2, corner3, corner4;
+    geometry_msgs::Point diagonal_corner_1, diagonal_corner_2;
 
     // Start with the perpendicular offset for width
     double half_width = width / 2.0;
 
-    // Calculate the four corners
     // Corner behind start (negative direction along the line)
-    corner1.x = start.x - back_padding * dx + half_width * perp_dx;
-    corner1.y = start.y - back_padding * dy + half_width * perp_dy;
+    diagonal_corner_1.x = start.x - back_padding * dx + half_width * perp_dx;
+    diagonal_corner_1.y = start.y - back_padding * dy + half_width * perp_dy;
 
-    corner2.x = start.x - back_padding * dx - half_width * perp_dx;
-    corner2.y = start.y - back_padding * dy - half_width * perp_dy;
+    diagonal_corner_2.x = goal.x + front_padding * dx - half_width * perp_dx;
+    diagonal_corner_2.y = goal.y + front_padding * dy - half_width * perp_dy;
 
-    // Corner in front of goal (positive direction along the line)
-    corner3.x = goal.x + front_padding * dx - half_width * perp_dx;
-    corner3.y = goal.y + front_padding * dy - half_width * perp_dy;
-
-    corner4.x = goal.x + front_padding * dx + half_width * perp_dx;
-    corner4.y = goal.y + front_padding * dy + half_width * perp_dy;
-
-    // Find the bounding box (min/max coordinates)
-    std::vector<geometry_msgs::Point> corners = {corner1, corner2, corner3, corner4};
-
-    double min_x = corners[0].x;
-    double max_x = corners[0].x;
-    double min_y = corners[0].y;
-    double max_y = corners[0].y;
-
-    for (const auto& corner : corners) {
-        min_x = std::min(min_x, corner.x);
-        max_x = std::max(max_x, corner.x);
-        min_y = std::min(min_y, corner.y);
-        max_y = std::max(max_y, corner.y);
-    }
-
-    // Create the two diagonal corners for the rectangle
-    geometry_msgs::Point diagonal1, diagonal2;
-    diagonal1.x = min_x;
-    diagonal1.y = min_y;
-    diagonal2.x = max_x;
-    diagonal2.y = max_y;
-
-    return Rectangle(diagonal1, diagonal2);
+    return Rectangle(diagonal_corner_1, diagonal_corner_2, width);
   }
 
 

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -25,6 +25,7 @@
 #include "nlohmann/json.hpp"
 #include "geometry_msgs/Quaternion.h"
 #include "geometry_msgs/Pose.h"
+#include "ros/node_handle.h"
 #include "tf2/utils.h"
 #include "costmap_2d/costmap_2d_ros.h"
 #include "costmap_2d/inflation_layer.h"
@@ -82,38 +83,65 @@ public:
       return (dot < 0);
     }
 
-    /**
-    * @brief Publish an arrow marker at a given pose for debugging
-    * @param marker_publisher ros::Publisher object
-    * @param pose the pose where to publish the arrow marker
-    * @param marker_namespace the namespace to group the marker
-    * @return
-    */
-    static inline void publishArrowMarker(const ros::Publisher &marker_publisher, const geometry_msgs::PoseStamped &pose, const std::string &marker_namespace, const int &id){
-      if (marker_publisher.getNumSubscribers() < 1) {
-        return;
-      }
-
-      visualization_msgs::Marker marker;
-      marker.header = pose.header;
-      marker.header.frame_id = marker.header.frame_id.empty() ? "map" : marker.header.frame_id;
-      marker.ns = marker_namespace;
-      marker.id = id;
-      marker.type = visualization_msgs::Marker::ARROW;
-      marker.action = visualization_msgs::Marker::ADD;
-      marker.pose = pose.pose;
-
-      // set scale and color
-      marker.scale.x = 0.4;
-      marker.scale.y = 0.035;
-      marker.scale.z = 0.1;
-      marker.color.a = 0.5;
-      marker.color.r = 0.0;
-      marker.color.g = 0.0;
-      marker.color.b = 1.0;
-
-      marker_publisher.publish(marker);
+  /**
+  * @brief Publish an arrow marker at a given pose for debugging
+  * @param marker_publisher ros::Publisher object
+  * @param pose the pose where to publish the arrow marker
+  * @param marker_namespace the namespace to group the marker
+  * @return
+  */
+  static inline void publishArrowMarker(const ros::Publisher &marker_publisher, const geometry_msgs::PoseStamped &pose, const std::string &marker_namespace, const int id){
+    if (marker_publisher.getNumSubscribers() < 1) {
+      return;
     }
+
+    visualization_msgs::Marker marker;
+    marker.header = pose.header;
+    marker.header.frame_id = marker.header.frame_id.empty() ? "map" : marker.header.frame_id;
+    marker.ns = marker_namespace;
+    marker.id = id;
+    marker.type = visualization_msgs::Marker::ARROW;
+    marker.action = visualization_msgs::Marker::ADD;
+    marker.pose = pose.pose;
+
+    // set scale and color
+    marker.scale.x = 0.4;
+    marker.scale.y = 0.035;
+    marker.scale.z = 0.1;
+    marker.color.a = 0.5;
+    marker.color.r = 0.0;
+    marker.color.g = 0.0;
+    marker.color.b = 1.0;
+
+    marker_publisher.publish(marker);
+  }
+
+  /**
+  * @brief Visualize a rectangle
+  * @param marker_publisher ros::Publisher object
+  * @param marker_namespace the namespace to group the marker
+  * @param frame_id frame_id of points
+  * @param id marker id
+  * @param p1,p2,p3,p1 the corners of the rectangle
+  * @return
+  */
+  static void publishRectangleMarker(const ros::Publisher &marker_publisher, const std::string& marker_namespace, const std::string& frame_id, const int id , const geometry_msgs::Point& p1, const geometry_msgs::Point& p2, const geometry_msgs::Point& p3, const geometry_msgs::Point& p4) {
+    visualization_msgs::Marker rectangle_marker;
+    rectangle_marker.header.frame_id = frame_id;
+    rectangle_marker.header.stamp = ros::Time::now();
+    rectangle_marker.ns = marker_namespace;
+    rectangle_marker.id = id;
+    rectangle_marker.type = visualization_msgs::Marker::LINE_STRIP;
+    rectangle_marker.action = visualization_msgs::Marker::ADD;
+    rectangle_marker.scale.x = 0.05;
+
+    rectangle_marker.color.r = 0.0f;
+    rectangle_marker.color.g = 1.0f;
+    rectangle_marker.color.b = 0.0f;
+    rectangle_marker.color.a = 0.7f;
+    rectangle_marker.points = {p1, p2, p3, p4, p1};
+    marker_publisher.publish(rectangle_marker);
+  }
 
   /**
   * @brief Check if the input poses are within specified tolerance
@@ -191,14 +219,13 @@ public:
         length = 1.0; // minimum length
     }
 
-    const double front_padding = 2.0; // padding in front of goal
-    const double back_padding = 2.0;  // padding behind start
+    const double front_padding = 1.0; // padding in front of goal
+    const double back_padding = 1.0;  // padding behind start
 
     geometry_msgs::Point diagonal_corner_1, diagonal_corner_2;
 
     const double half_width = width / 2.0;
 
-    // Corner behind start (negative direction along the line)
     diagonal_corner_1.x = start.x - back_padding * dx - half_width * dy;
     diagonal_corner_1.y = start.y - back_padding * dy + half_width * dx;
 

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -172,6 +172,79 @@ public:
   }
 
 
+  static Rectangle createSearchSpace(geometry_msgs::Point start, geometry_msgs::Point goal, double width) {
+    // Calculate the direction vector from start to goal
+    double dx = goal.x - start.x;
+    double dy = goal.y - start.y;
+
+    // Calculate the length of the line segment
+    double length = sqrt(dx * dx + dy * dy);
+
+    // Normalize the direction vector
+    if (length > 0) {
+        dx /= length;
+        dy /= length;
+    } else {
+        // If start and goal are the same point, use arbitrary direction
+        dx = 1.0;
+        dy = 0.0;
+        length = 1.0; // minimum length
+    }
+
+    // Calculate perpendicular vector (rotated 90 degrees counterclockwise)
+    double perp_dx = -dy;
+    double perp_dy = dx;
+
+    // Define padding (you can adjust these values as needed)
+    const double front_padding = 2.0; // padding in front of goal
+    const double back_padding = 2.0;  // padding behind start
+
+    // Calculate the four corners of the rectangle
+    geometry_msgs::Point corner1, corner2, corner3, corner4;
+
+    // Start with the perpendicular offset for width
+    double half_width = width / 2.0;
+
+    // Calculate the four corners
+    // Corner behind start (negative direction along the line)
+    corner1.x = start.x - back_padding * dx + half_width * perp_dx;
+    corner1.y = start.y - back_padding * dy + half_width * perp_dy;
+
+    corner2.x = start.x - back_padding * dx - half_width * perp_dx;
+    corner2.y = start.y - back_padding * dy - half_width * perp_dy;
+
+    // Corner in front of goal (positive direction along the line)
+    corner3.x = goal.x + front_padding * dx - half_width * perp_dx;
+    corner3.y = goal.y + front_padding * dy - half_width * perp_dy;
+
+    corner4.x = goal.x + front_padding * dx + half_width * perp_dx;
+    corner4.y = goal.y + front_padding * dy + half_width * perp_dy;
+
+    // Find the bounding box (min/max coordinates)
+    std::vector<geometry_msgs::Point> corners = {corner1, corner2, corner3, corner4};
+
+    double min_x = corners[0].x;
+    double max_x = corners[0].x;
+    double min_y = corners[0].y;
+    double max_y = corners[0].y;
+
+    for (const auto& corner : corners) {
+        min_x = std::min(min_x, corner.x);
+        max_x = std::max(max_x, corner.x);
+        min_y = std::min(min_y, corner.y);
+        max_y = std::max(max_y, corner.y);
+    }
+
+    // Create the two diagonal corners for the rectangle
+    geometry_msgs::Point diagonal1, diagonal2;
+    diagonal1.x = min_x;
+    diagonal1.y = min_y;
+    diagonal2.x = max_x;
+    diagonal2.y = max_y;
+
+    return Rectangle(diagonal1, diagonal2);
+  }
+
   /**
   * @brief check if the path fits in a width_threshold wide aisle if it fits then it is considered straight
   * @param path vector of geometry_msgs::PoseStamped

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -127,7 +127,6 @@ public:
     return distance <= tolerance && yaw_offset <= tolerance;
   }
 
-
   /**
   * @brief checks if the pose is between pose_1 and pose_2
   * @param pose the pose which we want to check
@@ -172,6 +171,47 @@ public:
     return output_pose;
   }
 
+  static bool hasCuspPoint(const std::vector<geometry_msgs::PoseStamped>& path)
+  {
+    if (path.size() < 3) {
+      return false;
+    }
+
+    auto computeHeading = [](const geometry_msgs::PoseStamped& from,
+                            const geometry_msgs::PoseStamped& to) {
+      double dx = to.pose.position.x - from.pose.position.x;
+      double dy = to.pose.position.y - from.pose.position.y;
+      return (dx == 0.0 && dy == 0.0) ? NAN
+                                      : std::atan2(dy, dx);
+    };
+
+    auto angleDiff = [](double a, double b) {
+      double diff = a - b;
+      while (diff > M_PI) diff -= 2.0 * M_PI;
+      while (diff < -M_PI) diff += 2.0 * M_PI;
+      return diff;
+    };
+
+    for (size_t i = 1; i < path.size() - 1; ++i) {
+      double prev_heading = computeHeading(path[i-1], path[i]);
+      double curr_heading = computeHeading(path[i], path[i+1]);
+
+      if (std::isnan(prev_heading) || std::isnan(curr_heading)) {
+        continue;
+      }
+
+      double heading_diff = std::abs(angleDiff(curr_heading, prev_heading));
+      if (heading_diff > M_PI_2) {
+        ROS_INFO("Found cusp point at (%f, %f), heading diff: %f",
+                path[i].pose.position.x,
+                path[i].pose.position.y,
+                heading_diff);
+        return true;
+      }
+    }
+
+    return false;
+  }
 
   /**
   * Computes the length of given path, where the path is a vector of geometry_msgs::PoseStamped and the length is

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -363,13 +363,11 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (index >= max_index) {
         return false;
       }
-      auto iter = _graph.find(index);
-      if (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(&(iter->second), _search_info.getSearchSpace().value())) {
-        return false;
-      }
+
       if (!_search_info.allow_goal_overshoot){
+        auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-               if (isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal){
+               if (isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal || (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(&(iter->second), _search_info.getSearchSpace().value()))){
                 return false;
                }
             }
@@ -439,12 +437,8 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     {
       neighbor = *neighbor_iterator;
 
-      if (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(neighbor, _search_info.getSearchSpace().value())) {
-        continue;
-      }
-
       if (!_search_info.allow_goal_overshoot) {
-        if ((isBehindPose(neighbor, _search_info.getSearchBound())) != is_start_behind_goal) {
+        if ((isBehindPose(neighbor, _search_info.getSearchBound())) != is_start_behind_goal || (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(neighbor, _search_info.getSearchSpace().value()))) {
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -26,6 +26,8 @@
 #include <geometry_msgs/Pose.h>
 #include <geometry_msgs/Point.h>
 #include "mbf_msgs/GetPathResult.h"
+#include "smac_planner/node_2d.hpp"
+#include "smac_planner/types.hpp"
 #include "smac_planner/utils.hpp"
 
 #include "smac_planner/a_star.hpp"
@@ -130,6 +132,16 @@ void AStarAlgorithm<NodeT>::setSearchBounds(const geometry_msgs::Pose& search_bo
   _expander->setSearchBounds(search_bounds, start_point, allow_goal_overshoot);
 }
 
+template <typename NodeT>
+void AStarAlgorithm<NodeT>::removeSearchSpace(){
+  _search_info.removeSearchSpace();
+}
+
+template <typename NodeT>
+void AStarAlgorithm<NodeT>::setSearchSpace(const Rectangle& space){
+  _search_info.setSearchSpace(space);
+}
+
 
 template<typename NodeT>
 typename AStarAlgorithm<NodeT>::NodePtr AStarAlgorithm<NodeT>::addToGraph(
@@ -203,6 +215,25 @@ bool AStarAlgorithm<NodeT>::isBehindPose(
   typename NodeT::Coordinates node_coords = node->pose;
   const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
   return Utils::isBehindPose(node_in_world_frame.position, pose);
+}
+
+template<>
+bool AStarAlgorithm<Node2D>::isInsideSearchSpace(
+  const NodePtr & node,
+  const Rectangle& search_space
+)
+{
+  const Node2D::Coordinates node_coords = node->getCoords(node->getIndex());
+  const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
+  return search_space.pointInside(node_in_world_frame.position);
+}
+
+template<typename NodeT>
+bool AStarAlgorithm<NodeT>::isInsideSearchSpace(const NodePtr & node, const Rectangle& search_space)
+{
+  typename NodeT::Coordinates node_coords = node->pose;
+  const geometry_msgs::Pose node_in_world_frame =  Utils::getWorldCoords(node_coords.x, node_coords.y, _costmap);
+  return search_space.pointInside(node_in_world_frame.position);
 }
 
 template<typename NodeT>
@@ -336,7 +367,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (!_search_info.allow_goal_overshoot){
         auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-               if (isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal){
+               if (isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal || (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(&(iter->second), _search_info.getSearchSpace().value()))){
                 return false;
                }
             }
@@ -407,7 +438,7 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       neighbor = *neighbor_iterator;
 
       if (!_search_info.allow_goal_overshoot) {
-        if ((isBehindPose(neighbor, _search_info.getSearchBound())) != is_start_behind_goal) {
+        if ((isBehindPose(neighbor, _search_info.getSearchBound())) != is_start_behind_goal || (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(neighbor, _search_info.getSearchSpace().value()))) {
           continue;
         }
       }

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -364,14 +364,15 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
         return false;
       }
 
-      if (!_search_info.allow_goal_overshoot){
-        auto iter = _graph.find(index);
-        if (iter != _graph.end()) {
-               if (isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal || (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(&(iter->second), _search_info.getSearchSpace().value()))){
-                return false;
-               }
-            }
+      auto iter = _graph.find(index);
+      if (iter != _graph.end()) {
+        if (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(&(iter->second), _search_info.getSearchSpace().value())) {
+          return false;
         }
+        if (!_search_info.allow_goal_overshoot && isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal) {
+          return false;
+        }
+      }
       neighbor_rtn = addToGraph(index);
       return true;
     };
@@ -437,12 +438,13 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     {
       neighbor = *neighbor_iterator;
 
-      if (!_search_info.allow_goal_overshoot) {
-        if ((isBehindPose(neighbor, _search_info.getSearchBound())) != is_start_behind_goal || (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(neighbor, _search_info.getSearchSpace().value()))) {
-          continue;
-        }
-      }
+    if (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(neighbor, _search_info.getSearchSpace().value())) {
+      continue;
+    }
 
+    if (!_search_info.allow_goal_overshoot && (isBehindPose(neighbor, _search_info.getSearchBound()) != is_start_behind_goal)) {
+      continue;
+    }
       // 4.1) Compute the cost to go to this node
       g_cost = current_node->getAccumulatedCost() + current_node->getTraversalCost(neighbor);
 

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -363,11 +363,13 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
       if (index >= max_index) {
         return false;
       }
-
+      auto iter = _graph.find(index);
+      if (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(&(iter->second), _search_info.getSearchSpace().value())) {
+        return false;
+      }
       if (!_search_info.allow_goal_overshoot){
-        auto iter = _graph.find(index);
         if (iter != _graph.end()) {
-               if (isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal || (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(&(iter->second), _search_info.getSearchSpace().value()))){
+               if (isBehindPose(&(iter->second), _search_info.getSearchBound()) != is_start_behind_goal){
                 return false;
                }
             }
@@ -437,8 +439,12 @@ uint32_t AStarAlgorithm<NodeT>::createPath(
     {
       neighbor = *neighbor_iterator;
 
+      if (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(neighbor, _search_info.getSearchSpace().value())) {
+        continue;
+      }
+
       if (!_search_info.allow_goal_overshoot) {
-        if ((isBehindPose(neighbor, _search_info.getSearchBound())) != is_start_behind_goal || (_search_info.isSearchSpaceSet() && !isInsideSearchSpace(neighbor, _search_info.getSearchSpace().value()))) {
+        if ((isBehindPose(neighbor, _search_info.getSearchBound())) != is_start_behind_goal) {
           continue;
         }
       }

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -206,14 +206,6 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
     ROS_ERROR_NAMED("smac_planner_hybrid", "Path from waypoint to goal is not straight");
     return failed_result;
   }
-  // if the segment from waypoint to goal has a cusp point, then fail
-  if (Utils::hasCuspPoint(segment2.path())) {
-    PlanResult failed_result;
-    failed_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
-    failed_result.message = "Path from waypoint to goal contains cusp point";
-    ROS_ERROR_NAMED("smac_planner_hybrid", "Path from waypoint to goal contains cusp point");
-    return failed_result;
-  }
 
   // if the robot is not between the goal and the waypoint, then we set the search bounds to the waypoint.
   const bool is_robot_between_goal_and_waypoint = Utils::isBetweenPoints(start.pose, waypoint.pose, goal_pose.pose);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -199,6 +199,15 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
     return segment2;
   }
 
+  // if the segment from waypoint to goal has a cusp point, then fail
+  if (Utils::hasCuspPoint(segment2.path())) {
+    PlanResult failed_result;
+    failed_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
+    failed_result.message = "Path from waypoint to goal contains cusp point";
+    ROS_ERROR_NAMED("smac_planner_hybrid", "Path from waypoint to goal contains cusp point");
+    return failed_result;
+  }
+
   // if the robot is not between the goal and the waypoint, then we set the search bounds to the waypoint.
   const bool is_robot_between_goal_and_waypoint = Utils::isBetweenPoints(start.pose, waypoint.pose, goal_pose.pose);
   if (!is_robot_between_goal_and_waypoint) {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -29,6 +29,7 @@
 #include "smac_planner/node_hybrid.hpp"
 #include "smac_planner/types.hpp"
 #include "smac_planner/utils.hpp"
+#include "visualization_msgs/Marker.h"
 #include <base_local_planner/footprint_helper.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include "smac_planner/smac_planner_hybrid.hpp"
@@ -79,6 +80,7 @@ void SmacPlannerHybrid::initialize(
   _collision_pub = private_nh.advertise<nav_msgs::OccupancyGrid>("collision_map", 1);
   _planned_footprints_publisher = private_nh.advertise<visualization_msgs::MarkerArray>(
       "planned_footprints", 1);
+  _search_space_publisher = private_nh.advertise<visualization_msgs::Marker>("search_space_waypt_to_goal", 1);
 
   dsrv_ = std::make_unique<dynamic_reconfigure::Server<SmacPlannerHybridConfig>>(private_nh);
   dsrv_->setCallback(boost::bind(&SmacPlannerHybrid::reconfigureCB, this, _1, _2));
@@ -189,10 +191,10 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   // waypoint to goal pose
   PlanResult segment2;
 
-  Rectangle search_space = Utils::createSearchSpace(waypoint.pose.position, goal_pose.pose.position, 0.1);
+  _search_space = Utils::createSearchSpace(waypoint.pose.position, goal_pose.pose.position, 0.1);
 
   // set search space from waypoint to goal to get straight path
-  _a_star->setSearchSpace(search_space);
+  _a_star->setSearchSpace(_search_space.value());
   getPath(waypoint, goal_pose, tolerance, segment2);
   _a_star->removeSearchSpace();
 
@@ -380,6 +382,11 @@ void SmacPlannerHybrid::publishVisualisations(const std::vector<geometry_msgs::P
 
   if (waypoint_ptr) {
     Utils::publishArrowMarker(_waypoint_publisher, * waypoint_ptr, "goal_align_waypoint", 1);
+  }
+
+  if (_search_space.has_value()) {
+    std::vector<geometry_msgs::Point> search_space_corners = _search_space.value().getCorners();
+    Utils::publishRectangleMarker(_search_space_publisher, "waypt_to_goal_search_space", _global_frame, 1, search_space_corners[0], search_space_corners[1], search_space_corners[2], search_space_corners[3]);
   }
 }
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -189,7 +189,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
   // waypoint to goal pose
   PlanResult segment2;
 
-  Rectangle search_space = Utils::createSearchSpace(waypoint.pose.position, goal_pose.pose.position, 0.2);
+  Rectangle search_space = Utils::createSearchSpace(waypoint.pose.position, goal_pose.pose.position, 0.1);
 
   _a_star->setSearchSpace(search_space);
   getPath(waypoint, goal_pose, tolerance, segment2);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -206,13 +206,13 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
     return segment2;
   }
 
-  if (!Utils::isPathStraight(segment2.path())) {
-    PlanResult failed_result;
-    failed_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
-    failed_result.message = "Path from waypoint to goal is not straight";
-    ROS_ERROR_NAMED("smac_planner_hybrid", "Path from waypoint to goal is not straight");
-    return failed_result;
-  }
+  // if (!Utils::isPathStraight(segment2.path())) {
+  //   PlanResult failed_result;
+  //   failed_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
+  //   failed_result.message = "Path from waypoint to goal is not straight";
+  //   ROS_ERROR_NAMED("smac_planner_hybrid", "Path from waypoint to goal is not straight");
+  //   return failed_result;
+  // }
 
   // if the robot is not between the goal and the waypoint, then we set the search bounds to the waypoint.
   const bool is_robot_between_goal_and_waypoint = Utils::isBetweenPoints(start.pose, waypoint.pose, goal_pose.pose);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -206,14 +206,6 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
     return segment2;
   }
 
-  // if (!Utils::isPathStraight(segment2.path())) {
-  //   PlanResult failed_result;
-  //   failed_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
-  //   failed_result.message = "Path from waypoint to goal is not straight";
-  //   ROS_ERROR_NAMED("smac_planner_hybrid", "Path from waypoint to goal is not straight");
-  //   return failed_result;
-  // }
-
   // if the robot is not between the goal and the waypoint, then we set the search bounds to the waypoint.
   const bool is_robot_between_goal_and_waypoint = Utils::isBetweenPoints(start.pose, waypoint.pose, goal_pose.pose);
   if (!is_robot_between_goal_and_waypoint) {

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -199,6 +199,13 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
     return segment2;
   }
 
+  if (!Utils::isPathStraight(segment2.path())) {
+    PlanResult failed_result;
+    failed_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
+    failed_result.message = "Path from waypoint to goal is not straight";
+    ROS_ERROR_NAMED("smac_planner_hybrid", "Path from waypoint to goal is not straight");
+    return failed_result;
+  }
   // if the segment from waypoint to goal has a cusp point, then fail
   if (Utils::hasCuspPoint(segment2.path())) {
     PlanResult failed_result;

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -191,6 +191,7 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
 
   Rectangle search_space = Utils::createSearchSpace(waypoint.pose.position, goal_pose.pose.position, 0.1);
 
+  // set search space from waypoint to goal to get straight path
   _a_star->setSearchSpace(search_space);
   getPath(waypoint, goal_pose, tolerance, segment2);
   _a_star->removeSearchSpace();

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -21,6 +21,7 @@
 #include <boost/scope_exit.hpp>
 
 #include "costmap_2d/costmap_2d_ros.h"
+#include "geometry_msgs/Point.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "mbf_msgs/GetPathResult.h"
 #include "nav_msgs/Path.h"
@@ -187,7 +188,13 @@ PlanResult SmacPlannerHybrid::planWithWaypoint(
 
   // waypoint to goal pose
   PlanResult segment2;
+
+  Rectangle search_space = Utils::createSearchSpace(waypoint.pose.position, goal_pose.pose.position, 0.2);
+
+  _a_star->setSearchSpace(search_space);
   getPath(waypoint, goal_pose, tolerance, segment2);
+  _a_star->removeSearchSpace();
+
   if (!segment2.isValid())
   {
     // the segment is from waypoint to goal pose, so blocked start means blocked waypoint.

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -21,7 +21,6 @@
 #include <boost/scope_exit.hpp>
 
 #include "costmap_2d/costmap_2d_ros.h"
-#include "geometry_msgs/Point.h"
 #include "geometry_msgs/PoseStamped.h"
 #include "mbf_msgs/GetPathResult.h"
 #include "nav_msgs/Path.h"
@@ -29,7 +28,6 @@
 #include "smac_planner/node_hybrid.hpp"
 #include "smac_planner/types.hpp"
 #include "smac_planner/utils.hpp"
-#include "visualization_msgs/Marker.h"
 #include <base_local_planner/footprint_helper.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include "smac_planner/smac_planner_hybrid.hpp"
@@ -385,7 +383,7 @@ void SmacPlannerHybrid::publishVisualisations(const std::vector<geometry_msgs::P
   }
 
   if (_search_space.has_value()) {
-    std::vector<geometry_msgs::Point> search_space_corners = _search_space.value().getCorners();
+    const std::vector<geometry_msgs::Point> search_space_corners = _search_space.value().getCorners();
     Utils::publishRectangleMarker(_search_space_publisher, "waypt_to_goal_search_space", _global_frame, 1, search_space_corners[0], search_space_corners[1], search_space_corners[2], search_space_corners[3]);
   }
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <optional>
 #include <smac_planner/types.hpp>
 #include <geometry_msgs/Point.h>
 #include <smac_planner/utils.hpp>
@@ -17,6 +19,23 @@ geometry_msgs::Pose SearchInfo::getSearchBound(){
 void SearchInfo::setSearchBound(const geometry_msgs::Pose& search_bound){
   _search_bound = search_bound;
   is_start_behind_goal.reset();
+}
+
+void SearchInfo::setSearchSpace(const Rectangle& space) {
+  _search_space = space;
+}
+
+void SearchInfo::removeSearchSpace(){
+  _search_space.reset();
+}
+
+std::optional<Rectangle >SearchInfo::getSearchSpace() {
+  return _search_space;
+}
+
+bool SearchInfo::isSearchSpaceSet()
+{
+  return (_search_space.has_value());
 }
 
 bool SearchInfo::isStartBehindSearchBounds(){
@@ -82,4 +101,17 @@ PlanResult PlanResult::operator+(const PlanResult& other_result) const {
   combined.setPath(std::move(new_combined_path));
   return combined;
   }
+
+Rectangle::Rectangle(geometry_msgs::Point diagonal_corner_1, geometry_msgs::Point diagonal_corner_2) : diagonal_corner_1(diagonal_corner_1), diagonal_corner_2(diagonal_corner_2) {
+  _max_x = std::max(diagonal_corner_1.x, diagonal_corner_2.x);
+  _max_y = std::max(diagonal_corner_1.y, diagonal_corner_2.y);
+  _min_x = std::min(diagonal_corner_1.x, diagonal_corner_2.x);
+  _min_y = std::min(diagonal_corner_1.y, diagonal_corner_2.y);
+}
+
+bool Rectangle::pointInside(const geometry_msgs::Point& point) const {
+  return (point.x >= _min_x && point.x <= _max_x &&
+          point.y >= _min_y && point.y <= _max_y);
+}
+
 }  // namespace smac_planner

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -104,15 +104,15 @@ PlanResult PlanResult::operator+(const PlanResult& other_result) const {
   return combined;
   }
 
-Rectangle::Rectangle(geometry_msgs::Point diagonal_corner_1,
-                     geometry_msgs::Point diagonal_corner_2,
-                     double width)
+Rectangle::Rectangle(const geometry_msgs::Point& diagonal_corner_1,
+                     const geometry_msgs::Point& diagonal_corner_2,
+                     const double width)
     : _corner1(diagonal_corner_1),
       _corner2(diagonal_corner_2),
       _width(width)
 {
-    double dx = _corner2.x - _corner1.x;
-    double dy = _corner2.y - _corner1.y;
+    const double dx = _corner2.x - _corner1.x;
+    const double dy = _corner2.y - _corner1.y;
     _length = std::max(std::sqrt(dx * dx + dy * dy) , 0.01); // cannot be 0
 
     // Direction unit vector
@@ -126,6 +126,7 @@ std::vector<geometry_msgs::Point> Rectangle::getCorners() const {
     const double dy = _corner2.y - _corner1.y;
 
     // Corner 1
+
     geometry_msgs::Point p1;
     p1.x = _corner1.x - (dy / _length) * (_width / 2.0);
     p1.y = _corner1.y + (dx / _length) * (_width / 2.0);
@@ -152,12 +153,12 @@ std::vector<geometry_msgs::Point> Rectangle::getCorners() const {
 
 bool Rectangle::pointInside(const geometry_msgs::Point& point) const {
     // Translate point relative to corner1
-    double px = point.x - _corner1.x;
-    double py = point.y - _corner1.y;
+    const double px = point.x - _corner1.x;
+    const double py = point.y - _corner1.y;
 
     // Project onto direction and perpendicular axes
-    double proj_along = px * _dir.x + py * _dir.y;
-    double proj_perp  = px * -_dir.y + py * _dir.x;
+    const double proj_along = px * _dir.x + py * _dir.y;
+    const double proj_perp  = px * -_dir.y + py * _dir.x;
 
     // Check bounds
     return (proj_along >= 0 && proj_along <= _length &&

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -102,16 +102,42 @@ PlanResult PlanResult::operator+(const PlanResult& other_result) const {
   return combined;
   }
 
-Rectangle::Rectangle(geometry_msgs::Point diagonal_corner_1, geometry_msgs::Point diagonal_corner_2) : diagonal_corner_1(diagonal_corner_1), diagonal_corner_2(diagonal_corner_2) {
-  _max_x = std::max(diagonal_corner_1.x, diagonal_corner_2.x);
-  _max_y = std::max(diagonal_corner_1.y, diagonal_corner_2.y);
-  _min_x = std::min(diagonal_corner_1.x, diagonal_corner_2.x);
-  _min_y = std::min(diagonal_corner_1.y, diagonal_corner_2.y);
+Rectangle::Rectangle(geometry_msgs::Point diagonal_corner_1,
+                     geometry_msgs::Point diagonal_corner_2,
+                     double width)
+    : _corner1(diagonal_corner_1),
+      _corner2(diagonal_corner_2),
+      _width(width)
+{
+    double dx = _corner2.x - _corner1.x;
+    double dy = _corner2.y - _corner1.y;
+    _length = std::sqrt(dx * dx + dy * dy);
+
+    // Direction unit vector
+    _dir.x = dx / _length;
+    _dir.y = dy / _length;
+
+    // visualize();
 }
 
+// void Rectangle::visualize() {
+    // get_corners()
+// }
+
+// get_corners(){
+
+// }
 bool Rectangle::pointInside(const geometry_msgs::Point& point) const {
-  return (point.x >= _min_x && point.x <= _max_x &&
-          point.y >= _min_y && point.y <= _max_y);
-}
+    // Translate point relative to corner1
+    double px = point.x - _corner1.x;
+    double py = point.y - _corner1.y;
 
+    // Project onto direction and perpendicular axes
+    double proj_along = px * _dir.x + py * _dir.y;
+    double proj_perp  = px * -_dir.y + py * _dir.x;
+
+    // Check bounds
+    return (proj_along >= 0 && proj_along <= _length &&
+            std::abs(proj_perp) <= _width / 2.0);
+}
 }  // namespace smac_planner

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -3,6 +3,8 @@
 #include <smac_planner/types.hpp>
 #include <geometry_msgs/Point.h>
 #include <smac_planner/utils.hpp>
+#include "ros/node_handle.h"
+#include "visualization_msgs/Marker.h"
 
 namespace smac_planner
 {
@@ -111,22 +113,43 @@ Rectangle::Rectangle(geometry_msgs::Point diagonal_corner_1,
 {
     double dx = _corner2.x - _corner1.x;
     double dy = _corner2.y - _corner1.y;
-    _length = std::sqrt(dx * dx + dy * dy);
+    _length = std::max(std::sqrt(dx * dx + dy * dy) , 0.01); // cannot be 0
 
     // Direction unit vector
     _dir.x = dx / _length;
     _dir.y = dy / _length;
-
-    // visualize();
 }
 
-// void Rectangle::visualize() {
-    // get_corners()
-// }
+std::vector<geometry_msgs::Point> Rectangle::getCorners() const {
+    std::vector<geometry_msgs::Point> corners;
+    const double dx = _corner2.x - _corner1.x;
+    const double dy = _corner2.y - _corner1.y;
 
-// get_corners(){
+    // Corner 1
+    geometry_msgs::Point p1;
+    p1.x = _corner1.x - (dy / _length) * (_width / 2.0);
+    p1.y = _corner1.y + (dx / _length) * (_width / 2.0);
 
-// }
+    // Corner 2
+    geometry_msgs::Point p2;
+    p2.x = _corner2.x - (dy / _length) * (_width / 2.0);
+    p2.y = _corner2.y + (dx / _length) * (_width / 2.0);
+
+    // Corner 3
+    geometry_msgs::Point p3;
+    p3.x = _corner2.x + (dy / _length) * (_width / 2.0);
+    p3.y = _corner2.y - (dx / _length) * (_width / 2.0);
+
+    // Corner 4
+    geometry_msgs::Point p4;
+    p4.x = _corner1.x + (dy / _length) * (_width / 2.0);
+    p4.y = _corner1.y - (dx / _length) * (_width / 2.0);
+
+    corners = {p1, p2, p3, p4};
+    return corners;
+}
+
+
 bool Rectangle::pointInside(const geometry_msgs::Point& point) const {
     // Translate point relative to corner1
     double px = point.x - _corner1.x;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,10 +1,7 @@
-#include <algorithm>
 #include <optional>
 #include <smac_planner/types.hpp>
 #include <geometry_msgs/Point.h>
 #include <smac_planner/utils.hpp>
-#include "ros/node_handle.h"
-#include "visualization_msgs/Marker.h"
 
 namespace smac_planner
 {
@@ -31,12 +28,11 @@ void SearchInfo::removeSearchSpace(){
   _search_space.reset();
 }
 
-std::optional<Rectangle >SearchInfo::getSearchSpace() {
+std::optional<Rectangle >SearchInfo::getSearchSpace() const {
   return _search_space;
 }
 
-bool SearchInfo::isSearchSpaceSet()
-{
+bool SearchInfo::isSearchSpaceSet() const {
   return (_search_space.has_value());
 }
 


### PR DESCRIPTION
[AB#80884](https://dev.azure.com/rapyuta-robotics/flappter/_workitems/edit/80884)

Create a narrow rectangular search space around the waypoint the goal, then reject neighbors that are outside the search space when exploring to force straight path between waypoint and goal (allowed deviation is the width of the search space which is set as 0.1 meters wide). 