### PR TITLE
fix: path from waypt-goal is reversed

### DIFF
--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -377,7 +377,7 @@ uint32_t AStarAlgorithm<NodeT>::getStraightPath(
     path_coordinates.push_back(intermediate);
   }
 
-  // Add start
+  // Add start at the end
   path_coordinates.push_back(start_coords);
 
   if constexpr (!std::is_same<NodeT, Node2D>::value) {

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -318,7 +318,9 @@ uint32_t AStarAlgorithm<NodeT>::getStraightPath(
 
   std::vector<Coordinates> path_coordinates;
 
-  // Add goal
+  // Add goal first, start searching from goal and move towards start
+  // because the path is then reversed in smac_planner_hybrid.cpp,
+  // smac_planner_lattice.cpp, smac_planner_2d.cpp
   path_coordinates.push_back(goal_coords);
 
   // Simple interpolation between goal and start

--- a/src/a_star.cpp
+++ b/src/a_star.cpp
@@ -321,9 +321,9 @@ uint32_t AStarAlgorithm<NodeT>::getStraightPath(
   // Add goal
   path_coordinates.push_back(goal_coords);
 
-  // Simple interpolation between start and goal
-  const float dx = goal_coords.x - start_coords.x;
-  const float dy = goal_coords.y - start_coords.y;
+  // Simple interpolation between goal and start
+  const float dx = start_coords.x - goal_coords.x;
+  const float dy = start_coords.y - goal_coords.y;
   const float steps = std::max(std::abs(dx), std::abs(dy));
 
   // Add intermediate points along the straight line
@@ -333,12 +333,12 @@ uint32_t AStarAlgorithm<NodeT>::getStraightPath(
       }
     const float ratio = static_cast<float>(i) / steps;
     typename NodeT::Coordinates intermediate;
-    intermediate.x = start_coords.x + dx * ratio;
-    intermediate.y = start_coords.y + dy * ratio;
+    intermediate.x = goal_coords.x + dx * ratio;
+    intermediate.y = goal_coords.y + dy * ratio;
 
     if constexpr (!std::is_same<NodeT, Node2D>::value) {
       // Only non-Node2D has theta
-      intermediate.theta = start_coords.theta;
+      intermediate.theta = goal_coords.theta;
     }
 
     unsigned int index;

--- a/src/smac_planner_2d.cpp
+++ b/src/smac_planner_2d.cpp
@@ -275,6 +275,7 @@ nav_msgs::Path SmacPlanner2D::createPlan(
 
   // Convert to world coordinates
   plan.poses.reserve(path.size());
+  // reverse the path because in a_star.cpp backtracepath gives reversed path
   for (int i = path.size() - 1; i >= 0; --i) {
     pose.pose = getWorldCoords(path[i].x, path[i].y, costmap);
     plan.poses.push_back(pose);

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -599,6 +599,7 @@ void SmacPlannerHybrid::getPath(
 
   // Convert to world coordinates
   output_path.poses.reserve(path.size());
+  // reverse the path because in a_star.cpp backtracepath gives reversed path
   for (int i = path.size() - 1; i >= 0; --i) {
     pose.pose = Utils::getWorldCoords(path[i].x, path[i].y, costmap);
     pose.pose.orientation = Utils::getWorldOrientation(path[i].theta);

--- a/src/smac_planner_lattice.cpp
+++ b/src/smac_planner_lattice.cpp
@@ -343,6 +343,7 @@ nav_msgs::Path SmacPlannerLattice::createPlan(
   // Convert to world coordinates
   plan.poses.reserve(path.size());
   geometry_msgs::PoseStamped last_pose = pose;
+  // reverse the path because in a_star.cpp backtracepath gives reversed path
   for (int i = path.size() - 1; i >= 0; --i) {
     pose.pose = getWorldCoords(path[i].x, path[i].y, _costmap);
     pose.pose.orientation = Utils::getWorldOrientation(path[i].theta);


### PR DESCRIPTION
the path was being reversed here: https://github.com/rapyuta-robotics/smac_planner/blob/19a6d5fd9382605d4275043010497de0c0be695b/src/smac_planner_hybrid.cpp#L601

so now we get the reversed path in getStraightPath and when it is reversed again, it will be straight.