### PR TITLE
fix: don't overwrite error code given by astar->createPath

### DIFF
--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -591,9 +591,9 @@ void SmacPlannerHybrid::getPath(
     else if (num_iterations >= _a_star->getMaxIterations()) {
       plan_result.message = "Exceeded maximum iterations";
       plan_result.result_code = mbf_msgs::GetPathResult::PAT_EXCEEDED;
-    } else {
+    }
+    else if (result == mbf_msgs::GetPathResult::NO_PATH_FOUND) {
       plan_result.message = "No valid path found";
-      plan_result.result_code = mbf_msgs::GetPathResult::NO_PATH_FOUND;
     }
   }
 


### PR DESCRIPTION
It overwrites the error code in getPath in the end, the correct error code is given by astar->createPath