### PR TITLE
Add: missing LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Portions of this repository are available under one of the following licenses
+
+SPDX-ID:
+* LGPL-2.1-or-later
+* Apache-2.0
+* BSD-3-Clause
+* Apache-2.0 AND BSD-3-Clause
+
+Please see the package.xml file for each package to see the specific license for
+that package.
+
+Contributions to existing files should be made under the license of that file.
+New files should be made under the first license listed in the appropriate
+package.xml file
+
+For files that are not otherwise marked, they are provided under the Apache-2.0
+license.


### PR DESCRIPTION
When this repo was ported LICENCE was not added so adding the same as [the one used by Nav2 repo ](https://github.com/ros-navigation/navigation2/blob/main/LICENSE)

confirm that the [license in package.xml](https://github.com/rapyuta-robotics/smac_planner/blob/96aa207decb0974db2f386fbf133cee7a760ead3/package.xml#L7) also match the one in [package.xml of smac_planner in nav2](https://github.com/ros-navigation/navigation2/blob/d536d33be89a5291f72e08b6bbaa7f0f374a57e2/nav2_smac_planner/package.xml#L8)