### PR TITLE
add padding to collision map

### DIFF
--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -415,8 +415,8 @@ void SmacPlannerHybrid::collision(const geometry_msgs::Pose& robot_pose, const r
   }
 
   // Dimensions of the bounding box
-  const int width = max_x - min_x + 1;
-  const int height = max_y - min_y + 1;
+  const int width = max_x - min_x + 3;
+  const int height = max_y - min_y + 3;
 
   // Create occupancy grid
   nav_msgs::OccupancyGrid grid;


### PR DESCRIPTION
Sometimes the collision map only has one cell, which makes it difficult to spot in Rviz. This pr adds padding to make it larger and more visible
<img width="801" height="640" alt="image" src="https://github.com/user-attachments/assets/91d0ab40-aca3-4501-a7cd-705b1dc16fed" />
<img width="663" height="501" alt="image" src="https://github.com/user-attachments/assets/fbff6d87-4597-4194-ab2d-7572ef17f134" />
