### PR TITLE
fix: collision map is not published sometimes

### DIFF
--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -133,7 +133,7 @@ public:
   * @param input_pose the pose which we want to check
   * @param yaw yaw to convert
   */
-  static inline void yawToPose(geometry_msgs::Pose& input_pose, const double yaw) {
+  static inline void setYaw(const double yaw, geometry_msgs::Pose& input_pose) {
       tf2::Quaternion q;
       q.setRPY(0, 0, yaw);
       input_pose.orientation.x = q.x();

--- a/include/smac_planner/utils.hpp
+++ b/include/smac_planner/utils.hpp
@@ -129,6 +129,20 @@ public:
 
 
   /**
+  * @brief sets the orientation of a geometry_msgs::Pose from yaw
+  * @param input_pose the pose which we want to check
+  * @param yaw yaw to convert
+  */
+  static inline void yawToPose(geometry_msgs::Pose& input_pose, const double yaw) {
+      tf2::Quaternion q;
+      q.setRPY(0, 0, yaw);
+      input_pose.orientation.x = q.x();
+      input_pose.orientation.y = q.y();
+      input_pose.orientation.z = q.z();
+      input_pose.orientation.w = q.w();
+  }
+
+  /**
   * @brief checks if the pose is between pose_1 and pose_2
   * @param pose the pose which we want to check
   * @param pose_1 other pose

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -444,7 +444,6 @@ void SmacPlannerHybrid::collision(const geometry_msgs::Pose& robot_pose, const r
   collision_map_publisher.publish(grid);
 }
 
-
 void SmacPlannerHybrid::getPath(
     const geometry_msgs::PoseStamped & start,
     const geometry_msgs::PoseStamped & goal,
@@ -491,7 +490,10 @@ void SmacPlannerHybrid::getPath(
   if (_collision_checker->inCollision(mx, my, orientation_bin_id, _config.allow_unknown)) {
     plan_result.message = "Start pose is blocked";
     plan_result.result_code = mbf_msgs::GetPathResult::BLOCKED_START;
-    collision(start.pose, _collision_pub);
+    geometry_msgs::Pose collision_pose;
+    collision_pose.position = start.pose.position;
+    Utils::yawToPose(collision_pose, orientation_bin * _angle_bin_size);
+    collision(collision_pose, _collision_pub);
     return;
   }
 
@@ -518,7 +520,10 @@ void SmacPlannerHybrid::getPath(
   if (_collision_checker->inCollision(mx, my, orientation_bin_id, _config.allow_unknown)) {
     plan_result.message = "Goal pose is blocked";
     plan_result.result_code = mbf_msgs::GetPathResult::BLOCKED_GOAL;
-    collision(goal.pose, _collision_pub);
+    geometry_msgs::Pose collision_pose;
+    collision_pose.position = goal.pose.position;
+    Utils::yawToPose(collision_pose, orientation_bin * _angle_bin_size);
+    collision(collision_pose, _collision_pub);
     return;
   }
 

--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -490,9 +490,8 @@ void SmacPlannerHybrid::getPath(
   if (_collision_checker->inCollision(mx, my, orientation_bin_id, _config.allow_unknown)) {
     plan_result.message = "Start pose is blocked";
     plan_result.result_code = mbf_msgs::GetPathResult::BLOCKED_START;
-    geometry_msgs::Pose collision_pose;
-    collision_pose.position = start.pose.position;
-    Utils::yawToPose(collision_pose, orientation_bin * _angle_bin_size);
+    geometry_msgs::Pose collision_pose = start.pose;
+    Utils::setYaw(orientation_bin * _angle_bin_size, collision_pose);
     collision(collision_pose, _collision_pub);
     return;
   }
@@ -520,9 +519,8 @@ void SmacPlannerHybrid::getPath(
   if (_collision_checker->inCollision(mx, my, orientation_bin_id, _config.allow_unknown)) {
     plan_result.message = "Goal pose is blocked";
     plan_result.result_code = mbf_msgs::GetPathResult::BLOCKED_GOAL;
-    geometry_msgs::Pose collision_pose;
-    collision_pose.position = goal.pose.position;
-    Utils::yawToPose(collision_pose, orientation_bin * _angle_bin_size);
+    geometry_msgs::Pose collision_pose = goal.pose;
+    Utils::setYaw(orientation_bin * _angle_bin_size, collision_pose);
     collision(collision_pose, _collision_pub);
     return;
   }


### PR DESCRIPTION
Sometimes the planner says start pose blocked or goal pose blocked, but the collision map is not published in that case. Collision map is supposed to show what cells are blocking the footprint of the robot at start and goal pose. This pr fixes that.

The issue was that when planner says start is blocked, it is not checking the start pose, it checks the start x,y but changes the orientation to the nearest angle bin. The collision map was checking collision at start pose. Because of this small offset, it caused to skip one cell near the end of the footprint as it is long.

Before: 

https://github.com/user-attachments/assets/b791eb7a-a974-41ee-9667-a5844cb73faa



After:

https://github.com/user-attachments/assets/154491e0-1d3c-48fc-90c1-6afc65b8c87c



