### PR TITLE
fix: sometimes crash happens

### DIFF
--- a/src/smac_planner_hybrid.cpp
+++ b/src/smac_planner_hybrid.cpp
@@ -278,6 +278,8 @@ uint32_t SmacPlannerHybrid::makePlan(
   _planning_canceled = false;
 
   geometry_msgs::PoseStamped* waypoint_ptr = nullptr;
+  std::vector<geometry_msgs::PoseStamped> waypoints;
+
   BOOST_SCOPE_EXIT(&plan, &waypoint_ptr, this_) {
     this_->publishVisualisations(plan, waypoint_ptr);
   } BOOST_SCOPE_EXIT_END
@@ -295,7 +297,7 @@ uint32_t SmacPlannerHybrid::makePlan(
     _a_star->setSearchBounds(goal.pose, start.pose.position, _search_info.allow_goal_overshoot);
   }
 
-  std::vector<geometry_msgs::PoseStamped> waypoints = computeWaypoints(start, goal, tolerance);
+  waypoints = computeWaypoints(start, goal, tolerance);
 
   // If no waypoint, proceed with normal planning
   if (waypoints.size() ==0) {


### PR DESCRIPTION
[AB#94606](https://dev.azure.com/rapyuta-robotics/AMR/_workitems/edit/94606)
last log line before the crash: 
`Plan with single waypoint for goal alignment`

the waypoints vector is destroyed but waypoint_ptr still points to waypoints.


example of what happens: 
```
func{
    waypoint_ptr
    BOOST_SCOPE_EXIT {
        cout << "here"
    } BOOST_SCOPE_EXIT_END

    waypoints
    local_variable_1
    return
}
```
Destruction order will be:
```
local_variable_1
waypoints
scope-exit  prints "here"
waypoint_ptr
```

Happens rarely if some other program overrites the address at waypoint_ptr before BOOST_SCOPE_EXIT is executed